### PR TITLE
continuous integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ dependencies = [
     "opencv-python-headless",
     "pillow",
     "scikit-learn",
-    "tqdm",
+    "tensorboard",
     "torchvision",
+    "tqdm",
     "typeguard (==2.13.3)",
 ]
 
@@ -58,6 +59,7 @@ dev = [
     "flake8-pyproject",
     "isort",
     "pytest",
+    "pytest-html",
     "requests",
 ]
 

--- a/scripts/buildbot/README.md
+++ b/scripts/buildbot/README.md
@@ -38,12 +38,14 @@ II. Setup on axon (or other SLURM cluster):
         chmod +x ~/buildbot/build.sh
 
     Setup your conda environment, and configure the variables in build.sh.
+    Note that it was necessary to install packages via conda rather than pip on Axon, because
+    ffmpeg needs to be install via `conda install -c conda-forge opencv`.
 
 III. Test that this is working.
 
 From a server that meets the requirements of the self-hosted runner in I, run:
 
-    ssh axon 'sh beast/buildbot/build_srun.sh <PR NUMBER>'
+    ssh axon 'sh buildbot/build_srun.sh <PR NUMBER>'
 
 It should successfully run tests. If not, debug.
 

--- a/scripts/buildbot/build_srun.sh
+++ b/scripts/buildbot/build_srun.sh
@@ -2,4 +2,4 @@
 #   -X is needed for github cancel to work.
 #     Otherwise srun needs two successive ctrl-C / SIGINT to cancel
 #   -u was found to enable colors. --pty would also work.
-srun -X -u -t 1:00:00 -c4 --mem=8g --gres=gpu:2 beast/buildbot/build.sh $@
+srun -X -u -t 1:00:00 -c4 --mem=8g --gres=gpu:2 buildbot/build.sh $@


### PR DESCRIPTION
Set up continuous integration for beast on Zuckerman Institute's Axon cluster, following the pattern in the Lightning Pose repo: https://github.com/paninski-lab/lightning-pose/blob/main/scripts/buildbot/README