### PR TITLE
fix checkpointing and validation with InfoNCE

### DIFF
--- a/beast/data/datamodules.py
+++ b/beast/data/datamodules.py
@@ -145,35 +145,58 @@ class BaseDataModule(pl.LightningDataModule):
         return train_split, val_split, test_split
 
     def train_dataloader(self) -> torch.utils.data.DataLoader:
+        common_kwargs = dict(
+            num_workers=self.num_workers,
+            persistent_workers=True if self.num_workers > 0 else False,
+            pin_memory=True,
+            multiprocessing_context=multiprocessing.get_context(
+                'spawn') if self.num_workers > 0 else None,
+        )
         if self.use_sampler:
             self.sampler = ContrastBatchSampler(
                 dataset=self.train_dataset,
                 batch_size=self.train_batch_size,
                 seed=self.seed,
             )
+            return DataLoader(
+                self.train_dataset,
+                batch_sampler=self.sampler,
+                collate_fn=contrastive_collate_fn,
+                **common_kwargs,
+            )
         return DataLoader(
             self.train_dataset,
-            batch_size=None if self.use_sampler else self.train_batch_size,
-            num_workers=self.num_workers,
-            persistent_workers=True if self.num_workers > 0 else False,
-            pin_memory=True,  # Helps with GPU transfer
-            shuffle=True if not self.use_sampler else False,
-            sampler=self.sampler if self.use_sampler else None,
+            batch_size=self.train_batch_size,
+            shuffle=True,
             generator=torch.Generator().manual_seed(self.seed),
-            collate_fn=contrastive_collate_fn if self.use_sampler else None,
-            multiprocessing_context=multiprocessing.get_context(
-                'spawn') if self.num_workers > 0 else None,  # More stable on HPC
+            **common_kwargs,
         )
 
     def val_dataloader(self) -> torch.utils.data.DataLoader:
-        return DataLoader(
-            self.val_dataset,
-            batch_size=self.val_batch_size,
+        common_kwargs = dict(
             num_workers=self.num_workers,
             persistent_workers=True if self.num_workers > 0 else False,
             pin_memory=True,
             multiprocessing_context=multiprocessing.get_context(
                 'spawn') if self.num_workers > 0 else None,
+        )
+        if self.use_sampler:
+            val_sampler = ContrastBatchSampler(
+                dataset=self.val_dataset,
+                batch_size=self.val_batch_size,
+                seed=self.seed,
+                shuffle=False,
+            )
+            return DataLoader(
+                self.val_dataset,
+                batch_sampler=val_sampler,
+                collate_fn=contrastive_collate_fn,
+                **common_kwargs,
+            )
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.val_batch_size,
+            **common_kwargs,
         )
 
     def test_dataloader(self) -> torch.utils.data.DataLoader:

--- a/beast/data/samplers.py
+++ b/beast/data/samplers.py
@@ -172,9 +172,11 @@ class ContrastBatchSampler(Sampler):
                 i = anchor_indices[idx_cursor]
 
                 # Find valid positive indices
+                # pos_indices values are local (subset) indices from extract_anchor_indices,
+                # so they are always valid within the subset — only filter by used.
                 valid_positives = [
                     p for p in self.pos_indices[i]
-                    if p in self.dataset_indices and p not in used
+                    if p not in used
                 ]
 
                 if not valid_positives:

--- a/beast/train.py
+++ b/beast/train.py
@@ -179,11 +179,23 @@ def train(config: dict, model, output_dir: str | Path):
         num_nodes=config['training']['num_nodes'],
         max_epochs=max_epochs,
         min_epochs=min_epochs,
-        check_val_every_n_epoch=config['training'].get('check_val_every_n_epoch', 1),
+        # With use_distributed_sampler=False, Lightning can't determine epoch
+        # length from the DataLoader, so epoch-boundary validation never fires.
+        # Workaround: use step-based val_check_interval instead.
+        check_val_every_n_epoch=(
+            None if not use_distributed_sampler
+            else config['training'].get('check_val_every_n_epoch', 1)
+        ),
+        val_check_interval=(
+            len(datamodule.train_dataloader()) * config['training'].get('check_val_every_n_epoch', 1)
+            if not use_distributed_sampler
+            else 1.0
+        ),
         log_every_n_steps=config['training'].get('log_every_n_steps', 10),
         callbacks=callbacks,
         logger=logger,
         accumulate_grad_batches=config['optimizer'].get('accumulate_grad_batches', 1),
+        num_sanity_val_steps=config['training'].get('num_sanity_val_steps', 2),
         sync_batchnorm=True,
         use_distributed_sampler=use_distributed_sampler,
     )
@@ -225,6 +237,7 @@ def get_callbacks(
             monitor='val_loss',
             mode='min',
             filename='{epoch}-{step}-best',
+            save_last=True,
         )
         callbacks.append(ckpt_best_callback)
 


### PR DESCRIPTION
Same as what was described here: https://github.com/paninski-lab/beast/issues/21

Three issues fixed:

1. ContrastBatchSampler bug: pos_indices from extract_anchor_indices are
   local (subset) indices, but were compared against global dataset_indices
   in the valid_positives filter. This caused all positives to be rejected
   for non-zero-based subsets (val/test), producing empty batches. Removed
   the incorrect check since local indices are valid by construction.

2. val_dataloader now uses ContrastBatchSampler and contrastive_collate_fn
   when use_sampler=True, matching the training dataloader. This enables
   proper InfoNCE computation during validation, so val_loss is logged and
   the best-model checkpoint callback can trigger.

3. Add save_last=True to ModelCheckpoint so a last.ckpt is always
   maintained, preventing total loss of training progress on interruption.
