### PR TITLE
fix lightning version to 2.5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "imgaug",
     "jaxtyping",
-    "lightning",
+    "lightning (~=2.5)",
     "numpy (<2.0.0)",
     "opencv-python-headless",
     "pillow",


### PR DESCRIPTION
fixing lightning version to 2.5.x in response to supply chain attack detailed [here](https://socket.dev/blog/lightning-pypi-package-compromised)