### PR TITLE
update numpy>=2.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,5 @@
 # See documentation in scripts/buildbot/README
-name: Run tests
+name: Run Tests
 
 on:
   pull_request_target:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Add SSH key to agent

--- a/beast/data/datamodules.py
+++ b/beast/data/datamodules.py
@@ -115,7 +115,7 @@ class BaseDataModule(pl.LightningDataModule):
 
         if rank_zero_only.rank == 0:
             print(
-                f'Number of images in the full dataset (train+val+test): {datalen}'
+                f'Number of images in the full dataset (train+val+test): {datalen}\n'
                 f'Dataset splits -- '
                 f'train: {len(self.train_dataset)}, '
                 f'val: {len(self.val_dataset)}, '

--- a/beast/data/datasets.py
+++ b/beast/data/datasets.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from typing import Callable
 
+import imgaug.augmenters.size as _iaa_size
 import numpy as np
 import torch
 from PIL import Image
@@ -15,6 +16,17 @@ from beast.data.types import ExampleDict
 
 _IMAGENET_MEAN = [0.485, 0.456, 0.406]
 _IMAGENET_STD = [0.229, 0.224, 0.225]
+
+#  monkey patch to fix imaug 0.4.2 compatability issue with numpy 2.x
+def _patched_prevent(axis_size, crop_start, crop_end):
+    result = _iaa_size._prevent_zero_sizes_after_crops_(
+        np.array([axis_size], dtype=np.int32),
+        np.array([crop_start], dtype=np.int32),
+        np.array([crop_end], dtype=np.int32),
+    )
+    return tuple(int(np.asarray(v).flat[0]) for v in result)
+
+_iaa_size._prevent_zero_size_after_crop_ = _patched_prevent
 
 
 @typechecked

--- a/beast/data/datasets.py
+++ b/beast/data/datasets.py
@@ -17,8 +17,9 @@ from beast.data.types import ExampleDict
 _IMAGENET_MEAN = [0.485, 0.456, 0.406]
 _IMAGENET_STD = [0.229, 0.224, 0.225]
 
-#  monkey patch to fix imaug 0.4.2 compatability issue with numpy 2.x
+
 def _patched_prevent(axis_size, crop_start, crop_end):
+    """Monkey patch to fix imaug 0.4.2 compatability issue with numpy 2.x"""
     result = _iaa_size._prevent_zero_sizes_after_crops_(
         np.array([axis_size], dtype=np.int32),
         np.array([crop_start], dtype=np.int32),
@@ -26,6 +27,8 @@ def _patched_prevent(axis_size, crop_start, crop_end):
     )
     return tuple(int(np.asarray(v).flat[0]) for v in result)
 
+
+#  monkey patch to fix imaug 0.4.2 compatability issue with numpy 2.x
 _iaa_size._prevent_zero_size_after_crop_ = _patched_prevent
 
 

--- a/beast/models/vits.py
+++ b/beast/models/vits.py
@@ -138,7 +138,7 @@ class VisionTransformer(BaseLightningModel):
 
     def predict_step(self, batch_dict: dict, batch_idx: int) -> dict:
         # set mask_ratio to 0 for inference
-        self.vit_mae.config.mask_ratio = 0
+        self.vit_mae.config.mask_ratio = 0.0
         # get model outputs
         results_dict = self.get_model_outputs(batch_dict, return_images=False)
         # reset mask_ratio to the original value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "imgaug",
+    "imaug",
     "jaxtyping",
     "lightning (~=2.5)",
-    "numpy (<2.0.0)",
+    "numpy (>=2.0.0)",
     "opencv-python-headless",
     "pillow",
     "scikit-learn",


### PR DESCRIPTION
The previous dependencies included to no-longer-maintained `imgaug` package, which prevented updating `numpy` to version `2.x`. This PR uses the drop-in (and currently maintained) `imaug` package (with the `g`) allowing for newer versions of numpy.