### PR TITLE
finer-grained inference output control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,183 @@
+# Claude Development Guidelines
+
+This file contains project-specific guidelines for Claude Code when working on this project.
+
+## Code Style
+
+### Comments
+- Use docstrings for all functions, classes, and modules
+- Follow Google-style docstrings
+- Add inline comments for complex logic
+- Avoid obvious comments
+- Comments should start with lowercase letters
+
+### Type Hints
+- Use type hints for all function parameters and return values
+- Import types from typing module when needed
+- use X | Y, list[X], dict[K, V] syntax; avoid typing imports for these
+
+### Imports
+- Group imports: standard library, third-party, local
+- Use absolute imports (e.g., `from <package_name>.<modlue_name> import func` not `from .<module_name> import func`)
+- Sort imports alphabetically within groups
+- Avoid wildcard imports
+
+### Code Formatting
+- Line length: 99 characters
+- Use 4 spaces for indentation
+- Follow PEP 8 conventions
+- Use meaningful variable names
+- Use idx for index
+- Use adjectives after nouns, such as idx_train and idx_test rather than train_idx and test_idx
+- Include newline at the end of every .py file
+- Do not allow trailing whitespace
+- Do not include whitespace for blank lines
+- Use single quotes for strings
+- Add a comma to the end of multi-line function arguments:
+```python
+foo(
+    param1,
+    param2,
+)
+```
+not
+```python
+foo(
+    param1,
+    param2
+)
+```
+
+### Misc
+- Use `pathlib.Path` instead of `os` for path handling
+- Use f-strings for all string interpolation, including `logger` calls and `print` statements — never `%s` formatting or `.format()`
+
+## Testing
+
+### Unit Tests
+- Use pytest framework
+- Test directory structure must mirror the source package structure exactly:
+  strip the `<package_name>/` prefix and prepend `tests/` — the rest of the path is identical.
+  `<package_name>/a/b/c.py` → `tests/a/b/test_c.py`, at every level of nesting without exception.
+  - Each subdirectory under `tests/` must have an `__init__.py`
+- Create test classes for each function
+- Use fixtures for common test data; place fixtures in a `conftest.py` in the same directory as the tests that use them
+- Test assets (e.g. sample images) live in an `assets/` subdirectory alongside the tests that use them
+- Aim for high test coverage
+- Test both success and failure cases
+
+### Test Structure
+```python
+class Test<function_name>:
+    """Test the function <function_name>."""
+
+    def test_<function_name>_<scenario>(self):
+        # Arrange
+        # Act
+        # Assert
+```
+
+### Mocking
+- Use unittest.mock for external dependencies
+- Mock at the boundary of your system
+- Use dependency injection when possible
+
+## Documentation
+
+### Docstrings
+```python
+def function_name(param1: Type1, param2: Type2) -> ReturnType:
+    """Brief description of function.
+    
+    Longer description if needed.
+    
+    Args:
+        param1: Description of param1
+        param2: Description of param2
+        
+    Returns:
+        Description of return value
+        
+    Raises:
+        ExceptionType: Description of when this exception is raised
+    """
+```
+If there are too many params for a single line, put one param per line, indented four spaces:
+```python
+def function_name(
+    param1: Type1,
+    param2: Type2,
+    param3: Type3,
+    param4: Type4,
+) -> ReturnType:
+```
+
+### Module Documentation
+- Every module should have a module-level docstring
+- Describe the purpose and main functionality
+
+## Error Handling
+
+### Exceptions
+- Use specific exception types
+- Provide meaningful error messages
+- Log errors appropriately
+- Use try/except blocks judiciously
+
+### Logging
+- Use Python's logging module
+- Include appropriate log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Log important events and errors
+- Include context in log messages
+
+## Project Structure
+
+### Package Organization
+- Keep modules focused and cohesive
+- Use clear, descriptive module names
+- Group related functionality together
+- Avoid circular imports
+
+### File Naming
+- Use snake_case for Python files
+- Use descriptive names
+- Group related files in subdirectories
+
+## CLI Guidelines
+
+### Command Structure
+- Use subcommands for different operations
+- Provide clear help messages
+- Validate input parameters
+- Handle errors gracefully
+
+### Configuration
+- Use sensible defaults
+- Validate configuration before execution
+
+## Dependencies
+
+### Adding Dependencies
+- Only add dependencies that are truly needed
+- Prefer well-maintained packages
+- Do not pin versions
+- Update pyproject.toml and document changes
+
+### Version Management
+- Use semantic versioning
+- Update version in pyproject.toml
+- Tag releases appropriately
+
+## Git Workflow
+
+### Commits
+- Write clear, descriptive commit messages
+- Make atomic commits
+- Include tests with feature commits
+- Run tests before committing
+
+### Branches
+- Use feature branches for development
+- Keep branches focused and short-lived
+- Merge with pull requests
+- Delete merged branches

--- a/beast/cli/commands/predict.py
+++ b/beast/cli/commands/predict.py
@@ -77,7 +77,7 @@ def handle(args):
             video_file=args.input,
             output_dir=args.output,
             batch_size=args.batch_size,
-            save_latents=True,
+            save_latents=args.save_latents,
             save_reconstructions=args.save_reconstructions,
         )
 
@@ -102,7 +102,7 @@ def handle(args):
                     video_file=video_file,
                     output_dir=args.output,
                     batch_size=args.batch_size,
-                    save_latents=True,
+                    save_latents=args.save_latents,
                     save_reconstructions=args.save_reconstructions,
                 )
         else:

--- a/beast/data/datasets.py
+++ b/beast/data/datasets.py
@@ -36,15 +36,25 @@ _iaa_size._prevent_zero_size_after_crop_ = _patched_prevent
 class BaseDataset(torch.utils.data.Dataset):
     """Base dataset that contains images."""
 
-    def __init__(self, data_dir: str | Path, imgaug_pipeline: Callable | None) -> None:
+    def __init__(
+        self,
+        data_dir: str | Path,
+        imgaug_pipeline: Callable | None,
+        num_channels: int = 3,
+    ) -> None:
         """Initialize a dataset for autoencoder models.
 
         Parameters
         ----------
         data_dir: absolute path to data directory
         imgaug_transform: imgaug transform pipeline to apply to images
+        num_channels: number of output channels; 1 loads as grayscale then converts to RGB,
+            3 loads directly as RGB
 
         """
+        if num_channels not in (1, 3):
+            raise ValueError(f'num_channels must be 1 or 3, got {num_channels}')
+        self.num_channels = num_channels
         log_step(f"BaseDataset.__init__ called with data_dir: {data_dir}", level='debug')
         self.data_dir = Path(data_dir)
         if not self.data_dir.is_dir():
@@ -104,8 +114,10 @@ class BaseDataset(torch.utils.data.Dataset):
         img_path = self.image_list[idx]
 
         # read image from file and apply transformations (if any)
-        # if 1 color channel, change to 3.
-        image = Image.open(img_path).convert('RGB')
+        if self.num_channels == 1:
+            image = Image.open(img_path).convert('L').convert('RGB')
+        else:
+            image = Image.open(img_path).convert('RGB')
         if self.imgaug_pipeline is not None:
             # expands add batch dim for imgaug
             transformed_images = self.imgaug_pipeline(images=np.expand_dims(image, axis=0))

--- a/beast/inference.py
+++ b/beast/inference.py
@@ -444,6 +444,7 @@ def predict_images(
     batch_size: int = 32,
     save_latents: bool = False,
     save_reconstructions: bool = True,
+    num_channels: int = 3,
 ) -> dict[str, Any]:
     """Run inference on images using a trained model and save results.
 
@@ -460,6 +461,8 @@ def predict_images(
     batch_size: number of images to process in each batch
     save_latents: whether to save latent representations as .npy files in a 'latents/' subdirectory
     save_reconstructions: whether to save reconstructed images as PNG files
+    num_channels: number of image channels; 1 loads as grayscale then converts to RGB, 3 loads
+        as RGB
 
     Returns
     -------
@@ -484,6 +487,7 @@ def predict_images(
     dataset = BaseDataset(
         data_dir=source_dir,
         imgaug_pipeline=None,
+        num_channels=num_channels,
     )
 
     # dataloader

--- a/beast/inference.py
+++ b/beast/inference.py
@@ -333,10 +333,9 @@ class VideoPredictionHandler:
         save_latents: bool = True
     ) -> dict[str, Any]:
         """Process a batch of predictions."""
-        reconstructions = predictions['reconstructions']
-        latents = predictions['latents']
 
-        batch_size = reconstructions.shape[0]
+        latents = predictions['latents']
+        batch_size = latents.shape[0]
 
         # process each frame in the batch
         for i in range(batch_size):
@@ -348,6 +347,8 @@ class VideoPredictionHandler:
 
             # save reconstruction frame to video
             if save_reconstructions:
+                reconstructions = predictions['reconstructions']
+
                 if self.reconstruction_writer is None:
                     self._init_video_writer()
 
@@ -442,7 +443,7 @@ def predict_images(
     output_dir: str | Path,
     source_dir: str | Path,
     batch_size: int = 32,
-    save_latents: bool = False,
+    save_latents: bool = True,
     save_reconstructions: bool = True,
     num_channels: int = 3,
 ) -> dict[str, Any]:
@@ -498,6 +499,9 @@ def predict_images(
         shuffle=False,
     )
 
+    # configure model predict behavior before handing off to trainer
+    model.return_reconstructions = save_reconstructions
+
     # run inference
     trainer = pl.Trainer(accelerator='gpu', devices=1, logger=False)
     predictions = trainer.predict(model, dataloaders=dataloader, return_predictions=True)
@@ -518,7 +522,7 @@ def predict_video(
     output_dir: str | Path,
     video_file: str | Path,
     batch_size: int = 32,
-    save_latents: bool = False,
+    save_latents: bool = True,
     save_reconstructions: bool = True,
 ) -> None:
     """Run inference on video using a trained model and save results.
@@ -545,6 +549,9 @@ def predict_video(
         video_file=video_file,
         batch_size=batch_size,
     )
+
+    # configure model predict behavior before handing off to trainer
+    model.return_reconstructions = save_reconstructions
 
     # run inference
     trainer = pl.Trainer(accelerator='gpu', devices=1, logger=False)

--- a/beast/models/base.py
+++ b/beast/models/base.py
@@ -21,6 +21,7 @@ class BaseLightningModel(pl.LightningModule):
         self.config = config
         self.seed = config['model']['seed']
         torch.manual_seed(self.seed)
+        self.return_reconstructions = True
 
         self.save_hyperparameters(config)
         # Child classes implement architecture setup

--- a/beast/models/resnets.py
+++ b/beast/models/resnets.py
@@ -75,15 +75,21 @@ class ResnetAutoencoder(BaseLightningModel):
         xhat = self.decoder(features)
         return xhat, z
 
-    def get_model_outputs(self, batch_dict: dict, return_images: bool = True) -> dict:
+    def get_model_outputs(
+        self,
+        batch_dict: dict,
+        return_images: bool = True,
+        return_reconstructions: bool = True,
+    ) -> dict:
         x = batch_dict['image']
         xhat, z = self.forward(x)
         results_dict = {
-            'reconstructions': xhat,
             'latents': z,
         }
         if return_images:
             results_dict['images'] = x
+        if return_reconstructions:
+            results_dict['reconstructions'] = xhat
         return results_dict
 
     def compute_loss(
@@ -105,7 +111,11 @@ class ResnetAutoencoder(BaseLightningModel):
         return mse_loss, log_list
 
     def predict_step(self, batch_dict: dict, batch_idx: int) -> dict:
-        results_dict = self.get_model_outputs(batch_dict, return_images=False)
+        results_dict = self.get_model_outputs(
+            batch_dict,
+            return_images=False,
+            return_reconstructions=self.return_reconstructions,
+        )
         results_dict['metadata'] = {
             'video': batch_dict['video'],
             'idx': batch_dict['idx'],

--- a/beast/models/vits.py
+++ b/beast/models/vits.py
@@ -214,8 +214,7 @@ class ViTMAE(ViTMAEForPreTraining):
             sequence_output = encoder_outputs[0]
             latent = self.vit.layernorm(sequence_output)
             if not return_latent:
-                # return the cls token and 0 loss if not return_latent
-                return latent[:, 0], 0
+                return {'latents': latent, 'loss': torch.zeros(1, device=latent.device)}
         if return_latent:
             return latent
         # extract cls latent

--- a/beast/models/vits.py
+++ b/beast/models/vits.py
@@ -74,9 +74,13 @@ class VisionTransformer(BaseLightningModel):
     def forward(
         self,
         x: Float[torch.Tensor, 'batch channels img_height img_width'],
+        return_recon: bool = True,
     ) -> Dict[str, torch.Tensor]:
-        results_dict = self.vit_mae(pixel_values=x, return_recon=True)
-        if self.config['model']['model_params'].get('use_perceptual_loss', False):
+        results_dict = self.vit_mae(pixel_values=x, return_recon=return_recon)
+        if (
+            self.config['model']['model_params'].get('use_perceptual_loss', False)
+            and 'reconstructions' in results_dict
+        ):
             results_dict['perceptual_loss'] = self.perceptual_loss(
                 results_dict['reconstructions'], x
             )
@@ -90,9 +94,14 @@ class VisionTransformer(BaseLightningModel):
 
         return results_dict
 
-    def get_model_outputs(self, batch_dict: dict, return_images: bool = True) -> dict:
+    def get_model_outputs(
+        self,
+        batch_dict: dict,
+        return_images: bool = True,
+        return_reconstructions: bool = True,
+    ) -> dict:
         x = batch_dict['image']
-        results_dict = self.forward(x)
+        results_dict = self.forward(x, return_recon=return_reconstructions)
         if return_images:
             results_dict['images'] = x
         return results_dict
@@ -140,7 +149,11 @@ class VisionTransformer(BaseLightningModel):
         # set mask_ratio to 0 for inference
         self.vit_mae.config.mask_ratio = 0.0
         # get model outputs
-        results_dict = self.get_model_outputs(batch_dict, return_images=False)
+        results_dict = self.get_model_outputs(
+            batch_dict,
+            return_images=False,
+            return_reconstructions=self.return_reconstructions,
+        )
         # reset mask_ratio to the original value
         self.vit_mae.config.mask_ratio = self.mask_ratio
         results_dict['metadata'] = {

--- a/beast/models/vits.py
+++ b/beast/models/vits.py
@@ -156,6 +156,11 @@ class VisionTransformer(BaseLightningModel):
         )
         # reset mask_ratio to the original value
         self.vit_mae.config.mask_ratio = self.mask_ratio
+        # just extract CLS tokens
+        cls_tokens = results_dict['latents'][:, 0, :].clone()
+        del results_dict['latents']
+        results_dict['latents'] = cls_tokens
+        # save metadata
         results_dict['metadata'] = {
             'video': batch_dict['video'],
             'idx': batch_dict['idx'],

--- a/beast/train.py
+++ b/beast/train.py
@@ -86,6 +86,7 @@ def train(config: dict, model, output_dir: str | Path):
     dataset = BaseDataset(
         data_dir=config['data']['data_dir'],
         imgaug_pipeline=imgaug_pipeline_,
+        num_channels=config['model']['model_params'].get('num_channels', 3),
     )
 
     # datamodule; breaks up dataset into train/val/test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "beast-backbones"
-version = "1.2.0"  # Update the version according to your source
+version = "1.3.0"  # Update the version according to your source
 description = "Behavioral analysis via self-supervised pretraining of transformers"
 license = "MIT"
 readme = "README.md"

--- a/scripts/buildbot/build.sh
+++ b/scripts/buildbot/build.sh
@@ -31,6 +31,8 @@ echo "Setting up environment..."
 source ~/.bashrc
 ml Miniforge-24.7.1-2
 conda activate $CONDA_ENV
+ml gcc/14.1                        # satisfies NumPy >= 2 requirement
+export LD_PRELOAD=/home/$(whoami)/.conda/envs/$CONDA_ENV/lib/libstdc++.so.6
 echo "Active conda environment: $CONDA_ENV"
 echo "Python location: $(which python)"
 echo "Pip location $(which pip)"
@@ -57,8 +59,7 @@ git checkout FETCH_HEAD
 pip install -e .
 echo "Pip install exit code: $?"
 pip show beast
-python -c "import sys; print('Python path:'); [print(p) for p in sys.path]"
-python -c "import beast; print('Beast import successful')"
+python -c "import beast; print('Beast location:', beast.__file__); print('Beast import successful')"
 
 # Run with html reporting.
 pytest --html=report.html --self-contained-html

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1,20 +1,42 @@
 from pathlib import Path
 
+import pytest
 import torch
 
+from beast.data.datasets import BaseDataset
 
-def test_base_dataset(base_dataset):
 
-    # check stored object properties
-    assert base_dataset.data_dir.is_dir()
-    assert len(base_dataset.image_list) > 0
+class TestBaseDataset:
 
-    # check batch properties
-    idx = 3
-    example = base_dataset[idx]
-    assert example['image'].shape == (3, 224, 224)
-    assert isinstance(example['image'], torch.Tensor)
-    assert example['video'] is not None
-    assert example['idx'] == idx
-    assert isinstance(example['image_path'], str)
-    assert Path(example['image_path']).is_file()
+    def test_rgb(self, base_dataset):
+
+        # check stored object properties
+        assert base_dataset.data_dir.is_dir()
+        assert len(base_dataset.image_list) > 0
+
+        # check batch properties
+        idx = 3
+        example = base_dataset[idx]
+        assert example['image'].shape == (3, 224, 224)
+        assert isinstance(example['image'], torch.Tensor)
+        assert example['video'] is not None
+        assert example['idx'] == idx
+        assert isinstance(example['image_path'], str)
+        assert Path(example['image_path']).is_file()
+
+    def test_grayscale(self, data_dir):
+        from beast.data.datasets import _IMAGENET_MEAN, _IMAGENET_STD
+        dataset = BaseDataset(data_dir=data_dir, imgaug_pipeline=None, num_channels=1)
+        example = dataset[0]
+        image = example['image']
+        assert image.shape == (3, 224, 224)
+        # undo per-channel ImageNet normalization before comparing channels
+        mean = torch.tensor(_IMAGENET_MEAN).view(3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD).view(3, 1, 1)
+        denorm = image * std + mean
+        assert torch.allclose(denorm[0], denorm[1], atol=1e-5)
+        assert torch.allclose(denorm[1], denorm[2], atol=1e-5)
+
+    def test_invalid_num_channels(self, data_dir):
+        with pytest.raises(ValueError, match='num_channels must be 1 or 3'):
+            BaseDataset(data_dir=data_dir, imgaug_pipeline=None, num_channels=2)

--- a/tests/models/test_resnets.py
+++ b/tests/models/test_resnets.py
@@ -2,90 +2,112 @@ import copy
 
 import torch
 
-
-def test_resnet_autoencoder_forward_features(config_ae):
-
-    from beast.models.resnets import ResnetAutoencoder
-
-    config = copy.deepcopy(config_ae)
-    config['model']['model_params']['num_latents'] = None  # no latents, just 2D features
-
-    input = torch.randn((5, 3, 224, 224))
-
-    config['model']['model_params']['backbone'] = 'resnet18'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], 512, 7, 7)
-
-    config['model']['model_params']['backbone'] = 'resnet34'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], 512, 7, 7)
-
-    config['model']['model_params']['backbone'] = 'resnet50'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], 2048, 7, 7)
-
-    config['model']['model_params']['backbone'] = 'resnet101'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], 2048, 7, 7)
-
-    config['model']['model_params']['backbone'] = 'resnet152'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], 2048, 7, 7)
+from beast.models.resnets import ResnetAutoencoder
 
 
-def test_resnet_autoencoder_forward_latents(config_ae):
+class TestResnetAutoencoder:
 
-    from beast.models.resnets import ResnetAutoencoder
+    def test_forward_features(self, config_ae):
 
-    config = copy.deepcopy(config_ae)
-    num_latents = 16
-    config['model']['model_params']['num_latents'] = num_latents
+        config = copy.deepcopy(config_ae)
+        config['model']['model_params']['num_latents'] = None  # no latents, just 2D features
 
-    input = torch.randn((5, 3, 224, 224))
+        input = torch.randn((5, 3, 224, 224))
 
-    config['model']['model_params']['backbone'] = 'resnet18'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], num_latents)
+        config['model']['model_params']['backbone'] = 'resnet18'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], 512, 7, 7)
 
-    config['model']['model_params']['backbone'] = 'resnet34'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], num_latents)
+        config['model']['model_params']['backbone'] = 'resnet34'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], 512, 7, 7)
 
-    config['model']['model_params']['backbone'] = 'resnet50'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], num_latents)
+        config['model']['model_params']['backbone'] = 'resnet50'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], 2048, 7, 7)
 
-    config['model']['model_params']['backbone'] = 'resnet101'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], num_latents)
+        config['model']['model_params']['backbone'] = 'resnet101'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], 2048, 7, 7)
 
-    config['model']['model_params']['backbone'] = 'resnet152'
-    model = ResnetAutoencoder(config)
-    reconstructions, latents = model(input)
-    assert reconstructions.shape == input.shape
-    assert latents.shape == (input.shape[0], num_latents)
+        config['model']['model_params']['backbone'] = 'resnet152'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], 2048, 7, 7)
+
+    def test_forward_latents(self, config_ae):
+
+        config = copy.deepcopy(config_ae)
+        num_latents = 16
+        config['model']['model_params']['num_latents'] = num_latents
+
+        input = torch.randn((5, 3, 224, 224))
+
+        config['model']['model_params']['backbone'] = 'resnet18'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], num_latents)
+
+        config['model']['model_params']['backbone'] = 'resnet34'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], num_latents)
+
+        config['model']['model_params']['backbone'] = 'resnet50'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], num_latents)
+
+        config['model']['model_params']['backbone'] = 'resnet101'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], num_latents)
+
+        config['model']['model_params']['backbone'] = 'resnet152'
+        model = ResnetAutoencoder(config)
+        reconstructions, latents = model(input)
+        assert reconstructions.shape == input.shape
+        assert latents.shape == (input.shape[0], num_latents)
+
+    def test_predict_step_return_reconstructions(self, config_ae):
+
+        config = copy.deepcopy(config_ae)
+        config['model']['model_params']['backbone'] = 'resnet18'
+        config['model']['model_params']['num_latents'] = 16
+        model = ResnetAutoencoder(config)
+        model.eval()
+
+        batch_dict = {
+            'image': torch.randn(2, 3, 224, 224),
+            'video': ['vid_a', 'vid_b'],
+            'idx': torch.tensor([0, 1]),
+            'image_path': ['/fake/0.png', '/fake/1.png'],
+        }
+
+        model.return_reconstructions = True
+        result = model.predict_step(batch_dict, 0)
+        assert 'reconstructions' in result
+
+        model.return_reconstructions = False
+        result = model.predict_step(batch_dict, 0)
+        assert 'reconstructions' not in result
 
 
 def test_resnet_autoencoder_integration_features(config_ae, run_model_test):
-
+    """Test ResNet autoencoder with spatial features, no bottleneck."""
     config = copy.deepcopy(config_ae)
     config['model']['model_params']['backbone'] = 'resnet18'
     config['model']['model_params']['num_latents'] = None  # no latents, just 2D features
@@ -94,6 +116,7 @@ def test_resnet_autoencoder_integration_features(config_ae, run_model_test):
 
 
 def test_resnet_autoencoder_integration_latents(config_ae, run_model_test):
+    """Test ResNet autoencoder with low-dimensional latent bottleneck."""
 
     config = copy.deepcopy(config_ae)
     config['model']['model_params']['backbone'] = 'resnet18'

--- a/tests/models/test_vits.py
+++ b/tests/models/test_vits.py
@@ -2,34 +2,56 @@ import copy
 
 import torch
 
-
-def test_vit_autoencoder_forward(config_vit):
-    from beast.models.vits import VisionTransformer
-    config = copy.deepcopy(config_vit)
-    input = torch.randn((5, 3, 224, 224))
-    model = VisionTransformer(config)
-    results = model.forward(input)
-    assert 'latents' in results
-    assert 'loss' in results
-    assert 'reconstructions' in results
-    assert results['reconstructions'].shape[0] == input.shape[0]
+from beast.models.vits import VisionTransformer
 
 
-def test_vit_autoencoder_get_model_outputs(config_vit):
-    from beast.models.vits import VisionTransformer
-    config = copy.deepcopy(config_vit)
-    input = torch.randn((5, 3, 224, 224))
-    batch_dict = {'image': input}
-    model = VisionTransformer(config)
-    results = model.get_model_outputs(batch_dict)
-    assert 'latents' in results
-    assert 'loss' in results
-    assert 'reconstructions' in results
-    assert 'images' in results
-    assert results['images'].shape == input.shape
+class TestVisionTransformer:
+
+    def test_forward(self, config_vit):
+        config = copy.deepcopy(config_vit)
+        input = torch.randn((5, 3, 224, 224))
+        model = VisionTransformer(config)
+        results = model.forward(input)
+        assert 'latents' in results
+        assert 'loss' in results
+        assert 'reconstructions' in results
+        assert results['reconstructions'].shape[0] == input.shape[0]
+
+    def test_get_model_outputs(self, config_vit):
+        config = copy.deepcopy(config_vit)
+        input = torch.randn((5, 3, 224, 224))
+        batch_dict = {'image': input}
+        model = VisionTransformer(config)
+        results = model.get_model_outputs(batch_dict)
+        assert 'latents' in results
+        assert 'loss' in results
+        assert 'reconstructions' in results
+        assert 'images' in results
+        assert results['images'].shape == input.shape
+
+    def test_predict_step_return_reconstructions(self, config_vit):
+        config = copy.deepcopy(config_vit)
+        model = VisionTransformer(config)
+        model.eval()
+
+        batch_dict = {
+            'image': torch.randn(2, 3, 224, 224),
+            'video': ['vid_a', 'vid_b'],
+            'idx': torch.tensor([0, 1]),
+            'image_path': ['/fake/0.png', '/fake/1.png'],
+        }
+
+        model.return_reconstructions = True
+        result = model.predict_step(batch_dict, 0)
+        assert 'reconstructions' in result
+
+        model.return_reconstructions = False
+        result = model.predict_step(batch_dict, 0)
+        assert 'reconstructions' not in result
 
 
 def test_vit_autoencoder_integration(config_vit, run_model_test):
+    """Test ViT autoencoder with basic masked autoencoder loss."""
     config = copy.deepcopy(config_vit)
     run_model_test(config=config)
 


### PR DESCRIPTION
  - BaseDataset now accepts num_channels (1 or 3): grayscale images are loaded via
  convert('L').convert('RGB') so downstream shape stays (3, H, W); wired through train.py and
  predict_images from config
  - BaseLightningModel gains a return_reconstructions flag (default True); both ResnetAutoencoder and
  VisionTransformer predict_step methods read it and skip decoder output when False — avoids computing and
   buffering reconstructions for long videos when only latents are needed
  - predict_images and predict_video set model.return_reconstructions = save_reconstructions before
  calling trainer.predict()
  - Fixed a latent bug in ViTMAE.forward: the fast inference path (eval + mask_ratio=0 +
  return_recon=False) was returning a bare tuple instead of a dict, which the return_reconstructions
  change made reachable for the first time
  - Added TestBaseDataset, TestResnetAutoencoder, TestVisionTransformer test classes covering the new
  behaviors

closes #15 