### PR TITLE
PR triggers build from own branch

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,7 @@ jobs:
         # -t flag is necessary to forward github cancellation event (SIGINT)
         run: |
           PR="${{ github.event.pull_request.number }}"
-          ssh -tt -p 55 mw3323@axon-remote.rc.zi.columbia.edu 'sh buildbot/build_srun.sh ${PR:-0}'
+          ssh -tt -p 55 mw3323@axon-remote.rc.zi.columbia.edu "sh buildbot/build_srun.sh ${PR:-0}"
 
       - name: Copy coverage report from remote
         run: |


### PR DESCRIPTION
fixes a bug where github action for tests was always building from `main` rather than the PR branch