### PR TITLE
Add BEAST3D model: ERayZer with DINOv3 tokenizer, GT cameras, frustum…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,7 +193,8 @@ scripts/preview_pointcloud.py
 scripts/smoke_erayzer_load.py
 scripts/viz_erayzer.py
 
-# fine-tune config holds a machine-specific init_checkpoint path (kept local)
+# fine-tune configs hold machine-specific data_dir / init_checkpoint paths (kept local)
 configs/multiview/erayzer_cheese3d_ft.yaml
+configs/multiview/beast3d_cheese3d_ft.yaml
 # local model checkpoints (machine-specific, large)
 checkpoints/

--- a/beast/config.py
+++ b/beast/config.py
@@ -35,6 +35,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
+from beast.models.beast3d.beast3d_config import Beast3DModelConfig
 from beast.models.beast_resnet.beast_resnet_config import ResnetModelConfig
 from beast.models.beast_vit.beast_vit_config import VitModelConfig
 from beast.models.erayzer.erayzer_config import (
@@ -104,8 +105,23 @@ class ERayZerBeastConfig(BaseModel):
     inference: bool = False
 
 
+class Beast3DBeastConfig(BaseModel):
+    """Complete top-level config for BEAST3D training runs.
+
+    BEAST3D reuses ERayZer's training and optimizer schemas; only the model
+    section differs (see beast.models.beast3d.beast3d_config.Beast3DModelConfig).
+    """
+
+    model: Beast3DModelConfig
+    training: ERayZerTrainingConfig
+    optimizer: ERayZerOptimizerConfig
+    data: DataConfig
+    inference: bool = False
+
+
 _MODEL_CONFIG_CLASSES: dict[str, type[BaseModel]] = {
     'erayzer': ERayZerBeastConfig,
+    'beast3d': Beast3DBeastConfig,
 }
 
 

--- a/beast/models/beast3d/__init__.py
+++ b/beast/models/beast3d/__init__.py
@@ -1,0 +1,11 @@
+"""BEAST3D multi-view 3DGS model package (ERayZer with DINOv3 + GT cameras)."""
+
+from beast.models.beast3d.beast3d_config import Beast3DModelConfig
+from beast.models.beast3d.beast3d_model import Beast3D
+from beast.models.beast3d.beast3d_train import train
+
+__all__ = [
+    'Beast3D',
+    'Beast3DModelConfig',
+    'train',
+]

--- a/beast/models/beast3d/beast3d_config.py
+++ b/beast/models/beast3d/beast3d_config.py
@@ -1,0 +1,37 @@
+"""Pydantic config schemas for the BEAST3D multi-view 3DGS model.
+
+BEAST3D is an ERayZer subclass, so its model config inherits every ERayZer model
+field and adds only the BEAST3D-specific knobs (DINOv3 tokenizer, frustum
+constraint, mask/alpha supervision, random-background compositing). Training and
+optimizer schemas are shared with ERayZer; see ``beast.config.Beast3DBeastConfig``.
+"""
+
+from typing import Literal
+
+from beast.models.erayzer.erayzer_config import ERayZerModelConfig
+
+
+class Beast3DModelConfig(ERayZerModelConfig):
+    """Model-section config for BEAST3D.
+
+    Inherits all ERayZer model fields (``image_tokenizer``, ``target_image``,
+    ``transformer``, ``pose_latent``, ``gaussians``, ``hard_pixelalign``, …).
+    BEAST3D reads ground-truth cameras from the batch, so the pose-prediction
+    branch is disabled by setting ``transformer.encoder_n_layer = 0``.
+    """
+
+    model_class: Literal['beast3d']
+
+    # DINOv3 image tokenizer (replaces the learned patch tokenizer when enabled).
+    # ViT-base/16 emits 768-dim patch tokens, so transformer.d must equal 768.
+    use_dinov3: bool = True
+    freeze_dinov3: bool = True
+    dino_model_name: str = 'facebook/dinov3-vitb16-pretrain-lvd1689m'
+
+    # restrict Gaussians to the intersection of all input view frustums
+    frustum_constraint: bool = True
+
+    # composite a random background into masked targets during training and
+    # supervise the rendered alpha against the foreground mask
+    random_background: bool = True
+    mask_loss_weight: float = 0.1

--- a/beast/models/beast3d/beast3d_model.py
+++ b/beast/models/beast3d/beast3d_model.py
@@ -1,0 +1,234 @@
+"""BEAST3D model: ERayZer with a DINOv3 tokenizer, GT cameras, and frustum 3DGS.
+
+BEAST3D specializes ERayZer for posed multi-view data: it reads ground-truth
+cameras from the batch (so the pose-prediction branch is disabled via
+``transformer.encoder_n_layer = 0``), tokenizes images with a frozen DINOv3
+backbone, restricts Gaussians to the intersection of the input view frustums,
+and supervises rendering with masked photometric + alpha losses against the GT
+foreground mask (with random-background compositing during training).
+
+Only the methods that differ from ERayZer are overridden; the encoder, Gaussian
+decoder, renderer, and forward pass are inherited unchanged.
+"""
+
+import logging
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+from beast.models.erayzer.erayzer_model import ERayZer
+from beast.nn.dino import DinoV3
+
+_logger = logging.getLogger(__name__)
+
+# ImageNet statistics: DINOv3 expects [0, 1] images normalized by these.
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+class Beast3D(ERayZer):
+    """ERayZer variant with a DINOv3 tokenizer, GT cameras, and frustum 3DGS."""
+
+    def __init__(self, config: dict) -> None:
+        """Initialize BEAST3D from a full config dict.
+
+        Parameters
+        ----------
+        config: full training/model config dict; reads ``config['model']`` for
+            the BEAST3D-specific flags (use_dinov3, freeze_dinov3,
+            dino_model_name, mask_loss_weight, random_background).
+
+        """
+        super().__init__(config)
+
+        model_cfg = config['model']
+        self.use_dinov3 = model_cfg.get('use_dinov3', True)
+        self.freeze_dinov3 = model_cfg.get('freeze_dinov3', True)
+        self.mask_loss_weight = model_cfg.get('mask_loss_weight', 0.1)
+        self.random_background = model_cfg.get('random_background', True)
+
+        if self.use_dinov3:
+            # the learned patch tokenizer is unused; swap in a DINOv3 backbone
+            del self.image_tokenizer
+            self.dinov3 = DinoV3(
+                model_name=model_cfg.get(
+                    'dino_model_name', 'facebook/dinov3-vitb16-pretrain-lvd1689m',
+                ),
+                freeze=self.freeze_dinov3,
+            )
+            if self.dinov3.embed_dim != self.d:
+                raise ValueError(
+                    f'DINOv3 embed_dim {self.dinov3.embed_dim} != transformer.d {self.d}; '
+                    'set model.transformer.d to match the DINOv3 backbone.'
+                )
+            mode = 'frozen' if self.freeze_dinov3 else 'trainable'
+            _logger.info(f'BEAST3D: using DINOv3 ViT-base tokenizer ({mode})')
+
+    def train(self, mode: bool = True) -> 'Beast3D':
+        """Pin a frozen DINOv3 to eval mode even while the rest of the model trains.
+
+        Parameters
+        ----------
+        mode: whether to set training mode (True) or eval mode (False).
+
+        Returns
+        -------
+        self.
+
+        """
+        super().train(mode)
+        if self.use_dinov3 and self.freeze_dinov3:
+            self.dinov3.eval()
+        return self
+
+    def _tokenize_images(self, images: torch.Tensor) -> torch.Tensor:
+        """Tokenize images with DINOv3 (ImageNet-normalized) or the base tokenizer.
+
+        Parameters
+        ----------
+        images: image tensor of shape [B, V, 3, H, W] in [0, 1].
+
+        Returns
+        -------
+        patch tokens of shape [B*V, n, d].
+
+        """
+        if not self.use_dinov3:
+            return super()._tokenize_images(images)
+        # DINOv3 expects ImageNet-normalized [0, 1] inputs
+        mean = images.new_tensor(_IMAGENET_MEAN).view(1, 1, 3, 1, 1)
+        std = images.new_tensor(_IMAGENET_STD).view(1, 1, 3, 1, 1)
+        images = (images - mean) / std
+        patch_tokens, _ = self.dinov3(images)  # [B, V, n, d]
+        return rearrange(patch_tokens, 'b v n d -> (b v) n d')
+
+    def _resolve_cameras(
+        self,
+        img_tokens: torch.Tensor,
+        b: int,
+        v_all: int,
+        n: int,
+        data: dict,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, bool]:
+        """Return ground-truth cameras from the batch (no pose prediction).
+
+        The dataset supplies ``c2w`` and ``fxfycxcy`` (intrinsics in pixels at the
+        render resolution). They are padded to ``v_all`` to line up with the
+        padded image tokens; padded views are never indexed by the input/target
+        selection so their values are irrelevant.
+
+        Parameters
+        ----------
+        img_tokens: image tokens (unused; cameras are read from ``data``).
+        b: batch size.
+        v_all: total number of (possibly padded) views.
+        n: patch tokens per view (unused).
+        data: batch dict with ``c2w`` [B, V, 4, 4] and ``fxfycxcy`` [B, V, 4].
+        device: compute device.
+
+        Returns
+        -------
+        tuple of (c2w [B, v_all, 4, 4], fxfycxcy [B, v_all, 4], normalized=False).
+
+        """
+        c2w = data['c2w'].to(device=device, dtype=torch.float32)
+        fxfycxcy = data['fxfycxcy'].to(device=device, dtype=torch.float32)
+        pad = v_all - c2w.shape[1]
+        if pad > 0:
+            c2w = torch.cat([c2w, c2w[:, -1:].expand(-1, pad, -1, -1)], dim=1)
+            fxfycxcy = torch.cat([fxfycxcy, fxfycxcy[:, -1:].expand(-1, pad, -1)], dim=1)
+        # intrinsics are already in pixels at the render resolution
+        return c2w, fxfycxcy, False
+
+    def _sample_background(
+        self,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        """Sample a random background colour during training, else None.
+
+        Parameters
+        ----------
+        device: device for the colour tensor.
+        dtype: dtype for the colour tensor.
+
+        Returns
+        -------
+        a random [3] colour during training (when enabled), otherwise None.
+
+        """
+        if self.training and self.random_background:
+            return torch.rand(3, device=device, dtype=dtype)
+        return None
+
+    def _prepare_target(
+        self,
+        target_image: torch.Tensor,
+        data: dict,
+        batch_idx: torch.Tensor,
+        target_idx: torch.Tensor,
+        bg_color: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Composite the background into the masked target and return the mask.
+
+        When the batch carries no foreground mask, falls back to the base
+        behaviour (raw target, no mask).
+
+        Parameters
+        ----------
+        target_image: target views of shape [B, v_target, 3, H, W].
+        data: batch dict; ``input_mask`` is [B, V, 1, H, W] when present.
+        batch_idx: batch index helper of shape [B, 1].
+        target_idx: target view indices of shape [B, v_target].
+        bg_color: background colour [3] used by the renderer, or None.
+
+        Returns
+        -------
+        tuple of (composited target [B, v_target, 3, H, W], mask [B, v_target, 1, H, W]).
+
+        """
+        input_mask = data.get('input_mask')
+        if input_mask is None:
+            return target_image, None
+        mask = input_mask[batch_idx, target_idx, ...].to(
+            device=target_image.device, dtype=target_image.dtype,
+        )
+        mask_fg = mask[:, :, :1, ...]  # first channel is the binary foreground
+        target = target_image * mask_fg
+        if bg_color is not None:
+            target = target + bg_color.view(1, 1, 3, 1, 1) * (1.0 - mask_fg)
+        return target, mask_fg
+
+    def compute_loss(
+        self,
+        stage: str,
+        **kwargs,
+    ) -> tuple[torch.Tensor, list[dict]]:
+        """Add a masked alpha-vs-foreground term to the base render loss.
+
+        The base loss already applies the foreground mask to the photometric
+        term (via ``pixel_mask``); this adds an MSE between the rendered alpha
+        and the GT mask, weighted by ``mask_loss_weight``.
+
+        Parameters
+        ----------
+        stage: one of 'train', 'val', 'test'.
+        **kwargs: model output fields from get_model_outputs.
+
+        Returns
+        -------
+        tuple of (total_loss, log_list).
+
+        """
+        loss, log_list = super().compute_loss(stage, **kwargs)
+        render_alphas = kwargs.get('render_alphas')
+        pixel_mask = kwargs.get('pixel_mask')
+        if render_alphas is not None and pixel_mask is not None and self.mask_loss_weight > 0:
+            # MSE on alpha (not BCE) avoids extreme gradients in the large bg region
+            alpha = render_alphas.clamp(1e-5, 1.0 - 1e-5)
+            mask_loss = F.mse_loss(alpha, pixel_mask.to(alpha.dtype))
+            loss = loss + self.mask_loss_weight * mask_loss
+            log_list.append({'name': f'{stage}_mask', 'value': mask_loss})
+        return loss, log_list

--- a/beast/models/beast3d/beast3d_train.py
+++ b/beast/models/beast3d/beast3d_train.py
@@ -1,0 +1,10 @@
+"""Training entry point for BEAST3D.
+
+Delegates to the shared beast.train.train function, which drives the
+MultiViewDataModule and step-based training used by the erayzer / beast3d
+model classes.
+"""
+
+from beast.train import train
+
+__all__ = ['train']

--- a/beast/models/erayzer/erayzer_model.py
+++ b/beast/models/erayzer/erayzer_model.py
@@ -537,6 +537,8 @@ class Renderer(nn.Module):
         width,
         C2W,
         fxfycxcy,
+        frustum_constraint: bool = False,
+        backgrounds: torch.Tensor | None = None,
     ):
         """Render Gaussians for all batch items and views.
 
@@ -551,6 +553,11 @@ class Renderer(nn.Module):
         width: render width in pixels.
         C2W: camera-to-world matrices of shape [b, v, 4, 4].
         fxfycxcy: intrinsics of shape [b, v, 4].
+        frustum_constraint: if True, restrict Gaussians to the intersection of
+            all view frustums (BEAST3D); off by default so base ERayZer is
+            unaffected.
+        backgrounds: optional background colour [3] passed to the rasteriser;
+            None keeps the renderer default (white).
 
         Returns
         -------
@@ -579,6 +586,8 @@ class Renderer(nn.Module):
                 buffers = render_opencv_cam_gsplat(
                     pc, height, width, C2W[i], fxfycxcy[i], self.sh_degree,
                     near_plane=near_plane,
+                    bg_color=backgrounds,
+                    frustum_constraint=frustum_constraint,
                 )
                 render = buffers['render']
                 assert render is not None
@@ -989,6 +998,79 @@ class ERayZer(BaseLightningModel):
         return pred_c2w, pred_fxfycxcy, True
 
     # ------------------------------------------------------------------
+    # Subclass hooks (no-ops in base ERayZer; overridden by BEAST3D)
+    # ------------------------------------------------------------------
+
+    def _tokenize_images(self, images: torch.Tensor) -> torch.Tensor:
+        """Tokenize images into per-patch embeddings.
+
+        Base ERayZer rescales ``[0, 1]`` images to ``[-1, 1]`` and applies the
+        learned patch tokenizer. Subclasses (BEAST3D) override this to use a
+        different tokenizer such as a frozen DINOv3 backbone.
+
+        Parameters
+        ----------
+        images: image tensor of shape [B, V, 3, H, W] in [0, 1].
+
+        Returns
+        -------
+        patch tokens of shape [B*V, n, d].
+
+        """
+        return self.image_tokenizer(images * 2.0 - 1.0)
+
+    def _sample_background(
+        self,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        """Return a background colour for rendering and target compositing.
+
+        Base ERayZer returns None, leaving the renderer's default background.
+        BEAST3D overrides this to randomize the background during training.
+
+        Parameters
+        ----------
+        device: device for the colour tensor.
+        dtype: dtype for the colour tensor.
+
+        Returns
+        -------
+        a colour tensor of shape [3], or None to keep the renderer default.
+
+        """
+        return None
+
+    def _prepare_target(
+        self,
+        target_image: torch.Tensor,
+        data: dict,
+        batch_idx: torch.Tensor,
+        target_idx: torch.Tensor,
+        bg_color: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Return the photometric target and an optional foreground mask.
+
+        Base ERayZer supervises the raw target image with no mask. BEAST3D
+        overrides this to composite ``bg_color`` into the masked background and
+        return the foreground mask for masked-photometric + alpha supervision.
+
+        Parameters
+        ----------
+        target_image: target views of shape [B, v_target, 3, H, W].
+        data: batch dict (source of GT masks for overrides).
+        batch_idx: batch index helper of shape [B, 1].
+        target_idx: target view indices of shape [B, v_target].
+        bg_color: the background colour used by the renderer, or None.
+
+        Returns
+        -------
+        tuple of (target_image, pixel_mask or None).
+
+        """
+        return target_image, None
+
+    # ------------------------------------------------------------------
     # BaseLightningModel interface
     # ------------------------------------------------------------------
 
@@ -1218,7 +1300,7 @@ class ERayZer(BaseLightningModel):
         SimpleNamespace with rendered images and auxiliary fields.
 
         """
-        image_all = data['image'] * 2.0 - 1.0  # [B, V, 3, H, W], rescale [0,1] → [-1,1]
+        image_all = data['image']  # [B, V, 3, H, W] in [0, 1]
 
         b, v_real, c, h, w = image_all.shape
         device = image_all.device
@@ -1241,8 +1323,8 @@ class ERayZer(BaseLightningModel):
         else:
             v_all = v_real
 
-        # tokenize all views and add spatial PE
-        img_tokens = self.image_tokenizer(image_all)  # [B*V, n, d]
+        # tokenize all views and add spatial PE (subclasses may swap the tokenizer)
+        img_tokens = self._tokenize_images(image_all)  # [B*V, n, d]
         _, n, d = img_tokens.shape
         if self.use_pe_embedding_layer:
             img_tokens = self.add_spatial_pe(
@@ -1361,9 +1443,15 @@ class ERayZer(BaseLightningModel):
             scale = fxfycxcy_target.new_tensor([width, height, width, height])
             fxfycxcy_target = fxfycxcy_target * scale
 
+        # frustum_constraint + random background are no-ops for base ERayZer
+        # (flag absent / _sample_background returns None) and active for BEAST3D.
+        frustum_constraint = self.config['model'].get('frustum_constraint', False)
+        bg_color = self._sample_background(device, image_all.dtype)
+
         render = self.renderer(
             xyz, features, scaling, rotation, opacity,
             height, width, C2W=c2w_target, fxfycxcy=fxfycxcy_target,
+            frustum_constraint=frustum_constraint, backgrounds=bg_color,
         )
 
         # input-view reconstruction: render the Gaussians back at the reference
@@ -1379,6 +1467,7 @@ class ERayZer(BaseLightningModel):
                 render_input = self.renderer(
                     xyz, features, scaling, rotation, opacity,
                     height, width, C2W=c2w_input, fxfycxcy=fxfycxcy_input_px,
+                    frustum_constraint=frustum_constraint,
                 ).render
 
         vis_only_results = None
@@ -1439,15 +1528,24 @@ class ERayZer(BaseLightningModel):
             pixelalign_xyz.append(pa_xyz)
         pixelalign_xyz = torch.stack(pixelalign_xyz, dim=0)
 
+        # photometric target + optional foreground mask (BEAST3D composites the
+        # background and returns a mask; base ERayZer returns the raw target, None)
+        target_image = data['image'][batch_idx, target_idx, ...]
+        target_image, pixel_mask = self._prepare_target(
+            target_image, data, batch_idx, target_idx, bg_color,
+        )
+
         return SimpleNamespace(
             ray_o=ray_o,
             gaussians=gaussians,
             pixelalign_xyz=pixelalign_xyz,
             image=data['image'],
             input_image=data['image'][batch_idx, input_idx.clamp(max=v_real - 1), ...],
-            target_image=data['image'][batch_idx, target_idx, ...],
+            target_image=target_image,
             render=render.render,
+            render_alphas=render.alpha,
             render_input=render_input,
+            pixel_mask=pixel_mask,
             c2w_input=c2w_input,
             fxfycxcy_input=fxfycxcy_input,
             c2w_target=c2w_target,

--- a/beast/models/registry.py
+++ b/beast/models/registry.py
@@ -26,6 +26,9 @@ CONFIG_REGISTRY: dict[str, type[BaseModel]] = {}
 
 def _register_all() -> None:
     """Import all model packages so they can populate the registries."""
+    from beast.models.beast3d.beast3d_config import Beast3DModelConfig
+    from beast.models.beast3d.beast3d_model import Beast3D
+    from beast.models.beast3d.beast3d_train import train as beast3d_train
     from beast.models.beast_resnet.beast_resnet_config import ResnetModelConfig
     from beast.models.beast_resnet.beast_resnet_model import ResnetAutoencoder
     from beast.models.beast_resnet.beast_resnet_train import train as resnet_train
@@ -47,6 +50,10 @@ def _register_all() -> None:
     MODEL_REGISTRY['erayzer'] = ERayZer
     TRAIN_REGISTRY['erayzer'] = erayzer_train
     CONFIG_REGISTRY['erayzer'] = ERayZerModelConfig
+
+    MODEL_REGISTRY['beast3d'] = Beast3D
+    TRAIN_REGISTRY['beast3d'] = beast3d_train
+    CONFIG_REGISTRY['beast3d'] = Beast3DModelConfig
 
 
 def get_model_class(model_class: str) -> type:

--- a/beast/rendering/gaussians_renderer.py
+++ b/beast/rendering/gaussians_renderer.py
@@ -755,6 +755,70 @@ class GaussianModel:
         self._rotation = torch.from_numpy(rots.astype(np.float32)).contiguous()
 
 
+def camera_frustum_constraint(
+    xyz: torch.Tensor,
+    opacity: torch.Tensor,
+    c2w: torch.Tensor,
+    fxfycxcy: torch.Tensor,
+    height: int,
+    width: int,
+    normalized: bool = False,
+) -> torch.Tensor:
+    """Zero the opacity of Gaussians outside the intersection of all view frustums.
+
+    A Gaussian is kept only when it projects inside the image bounds and in front
+    of *every* camera in ``c2w`` (logical AND across views), restricting the
+    rendered field to the space jointly observed by all input cameras. This is the
+    frustum constraint used by BEAST3D; the base ERayZer renderer leaves it off.
+
+    Parameters
+    ----------
+    xyz: Gaussian centres of shape [N, 3].
+    opacity: per-Gaussian opacity of shape [N, 1].
+    c2w: camera-to-world matrices of shape [V, 4, 4].
+    fxfycxcy: intrinsics of shape [V, 4].
+    height: image height in pixels.
+    width: image width in pixels.
+    normalized: True if intrinsics are normalized to [0, 1] rather than pixels.
+
+    Returns
+    -------
+    opacity with out-of-frustum Gaussians set to zero, shape [N, 1].
+
+    """
+    num_points = xyz.shape[0]
+    ones = torch.ones(num_points, 1, device=xyz.device, dtype=xyz.dtype)
+    xyz_h = torch.cat([xyz, ones], dim=-1)
+    valid = torch.ones(num_points, device=xyz.device, dtype=torch.bool)
+
+    for v in range(c2w.shape[0]):
+        w2c_v = torch.inverse(c2w[v])
+        fx, fy, cx, cy = fxfycxcy[v, 0], fxfycxcy[v, 1], fxfycxcy[v, 2], fxfycxcy[v, 3]
+
+        # transform into this camera's frame and project through the pinhole model
+        xyz_c = torch.matmul(xyz_h, w2c_v.transpose(-1, -2))[..., :3]
+        z = xyz_c[..., 2:3] + 1e-6
+        u = (xyz_c[..., 0:1] / z) * fx + cx
+        v_coord = (xyz_c[..., 1:2] / z) * fy + cy
+
+        # normalize pixel coords to [-1, 1] for the in-bounds test
+        if normalized:
+            u_norm = u * 2.0 - 1.0
+            v_norm = v_coord * 2.0 - 1.0
+        else:
+            u_norm = (u / (width - 1)) * 2.0 - 1.0
+            v_norm = (v_coord / (height - 1)) * 2.0 - 1.0
+
+        in_fov = (
+            (u_norm.squeeze(-1).abs() <= 1.0)
+            & (v_norm.squeeze(-1).abs() <= 1.0)
+            & (z.squeeze(-1) > 0)
+        )
+        valid = valid & in_fov
+
+    return torch.where(valid.unsqueeze(-1), opacity, torch.zeros_like(opacity))
+
+
 def render_opencv_cam_gsplat(
     pc: GaussianModel,
     height: int,
@@ -763,8 +827,9 @@ def render_opencv_cam_gsplat(
     fxfycxcy: torch.Tensor,
     sh_degree: int | None = None,
     near_plane: float = 0.2,
-    bg_color: tuple[float, float, float] | torch.Tensor = (1.0, 1.0, 1.0),
+    bg_color: tuple[float, float, float] | torch.Tensor | None = (1.0, 1.0, 1.0),
     render_depth: bool = False,
+    frustum_constraint: bool = False,
 ) -> dict[str, torch.Tensor | None]:
     """Render a batch of views using gsplat rasterisation.
 
@@ -779,10 +844,14 @@ def render_opencv_cam_gsplat(
     near_plane: near clipping plane distance.
     bg_color: background colour (1-D or 2-D tensor or tuple).
     render_depth: whether to also render a depth map.
+    frustum_constraint: if True, zero opacity for Gaussians outside the
+        intersection of all view frustums (BEAST3D); off by default.
 
     Returns
     -------
-    dict with keys 'render' ([V, 3, H, W]) and 'depth' ([V, 1, H, W] or None).
+    dict with keys 'render' ([V, 3, H, W]), 'depth' ([V, 1, H, W] or None),
+    'alpha' ([V, 1, H, W]), and 'sigmoid_opacity' ([N, 1], the opacity actually
+    rasterised, after any frustum masking).
 
     """
     means3D = pc.get_xyz
@@ -797,6 +866,8 @@ def render_opencv_cam_gsplat(
                 'Check model outputs and consider using float32 or clamping scales.'
             )
     num_cams = C2W.size(0)
+    if bg_color is None:
+        bg_color = (1.0, 1.0, 1.0)
     if torch.is_tensor(bg_color):
         bg_color = bg_color.to(device=C2W.device, dtype=torch.float32)
     else:
@@ -829,8 +900,11 @@ def render_opencv_cam_gsplat(
     intr[:, 1, 2] = fxfycxcy[:, 3]
     intr[:, 2, 2] = 1.0
 
+    if frustum_constraint:
+        opacity = camera_frustum_constraint(means3D, opacity, C2W, fxfycxcy, height, width)
+
     render_mode = 'RGB+ED' if render_depth else 'RGB'
-    render_colors, _, _ = rasterization(
+    render_colors, render_alphas, _ = rasterization(
         means3D, rotations, scales, opacity.squeeze(),
         shs, W2C, intr, width, height,
         near_plane=near_plane,
@@ -848,6 +922,8 @@ def render_opencv_cam_gsplat(
         'depth': (
             render_depth_map.permute(0, 3, 1, 2) if torch.is_tensor(render_depth_map) else None
         ),
+        'alpha': render_alphas.permute(0, 3, 1, 2),
+        'sigmoid_opacity': opacity,
     }
 
 

--- a/beast/train.py
+++ b/beast/train.py
@@ -98,9 +98,10 @@ def train(config: dict, model: BaseLightningModel, output_dir: str | Path) -> Ba
 
     model_class = config['model'].get('model_class', '').lower()
 
-    if model_class == 'erayzer':
+    if model_class in ('erayzer', 'beast3d'):
         if rank_zero_only.rank == 0:
             log_step('Creating MultiViewDataModule', level='debug')
+        # BEAST3D supervises the rendered alpha against GT foreground masks
         datamodule = MultiViewDataModule(
             data_dir=config['data']['data_dir'],
             image_size=config['model']['image_tokenizer']['image_size'],
@@ -109,6 +110,7 @@ def train(config: dict, model: BaseLightningModel, output_dir: str | Path) -> Ba
             train_fraction=config['training'].get('train_fraction', 0.9),
             num_workers=config['training']['num_workers'],
             seed=config['training'].get('seed', 0),
+            use_mask=(model_class == 'beast3d'),
         )
         datamodule.setup()
         if rank_zero_only.rank == 0:

--- a/configs/multiview/beast3d.yaml
+++ b/configs/multiview/beast3d.yaml
@@ -1,0 +1,123 @@
+# BEAST3D: ERayZer with a frozen DINOv3 tokenizer, ground-truth cameras, and
+# frustum-constrained 3D Gaussian splatting.
+#
+# Differences from erayzer.yaml:
+#   - cameras come from the dataset (c2w / fxfycxcy), so the pose-prediction
+#     branch is disabled: transformer.encoder_n_layer = 0
+#   - images are tokenized by a frozen DINOv3 ViT-base (d must be 768)
+#   - rendering is frustum-constrained and supervised with masked photometric +
+#     alpha losses against the GT foreground mask (random background during train)
+#
+# Run with: beast train --config configs/multiview/beast3d.yaml
+
+# ---------------------------------------------------------------------------
+# Model architecture
+# ---------------------------------------------------------------------------
+model:
+  model_class: beast3d
+  seed: 0
+  checkpoint: null            # path to .ckpt for fine-tuning or inference
+  init_checkpoint: null       # path / HF URL for weight-only warm-start
+
+  # BEAST3D-specific
+  use_dinov3: true            # frozen DINOv3 ViT-base tokenizer (d must be 768)
+  freeze_dinov3: true
+  dino_model_name: facebook/dinov3-vitb16-pretrain-lvd1689m
+  frustum_constraint: true    # restrict Gaussians to the intersection of input frustums
+  random_background: true     # composite a random background into masked targets (train)
+  mask_loss_weight: 0.1       # weight of the rendered-alpha vs foreground-mask MSE
+
+  image_tokenizer:
+    image_size: 256           # square input resolution (must match DINOv3 patches)
+    patch_size: 16            # DINOv3 ViT-base/16 → 16x16 = 256 patch tokens per view
+    in_channels: 3
+
+  target_image:
+    height: 256               # novel-view render resolution
+    width: 256
+
+  transformer:
+    d: 768                    # token embedding dimension (= DINOv3 embed_dim)
+    d_head: 64                # per-head dimension
+    encoder_n_layer: 0        # camera-prediction branch disabled (GT cameras)
+    encoder_geom_n_layer: 16  # geometry encoder depth (must be even)
+    use_qk_norm: true
+    special_init: true
+    depth_init: true
+    fix_decoder: false
+
+  pose_latent:                # unused when encoder_n_layer = 0 (kept for schema)
+    canonical: middle
+    mode: pairwise
+    representation: 6d
+
+  gaussians:
+    sh_degree: 3
+    range_setting:
+      type: linear_depth      # depth mapping for hard pixel alignment
+      near: 0.0
+      far: 8.0                # scene depth in world units; tune per dataset
+
+  hard_pixelalign: true       # project each Gaussian onto its source pixel ray
+  input_with_pe: true
+  mask_ratio: 0.0
+
+  # Gaussian activation biases
+  scaling_bias: -3.0
+  scaling_max: -2.0
+  opacity_bias: -2.0
+
+  near_plane: 0.2             # near clipping plane passed to gsplat
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+training:
+  seed: 0
+  num_views: 10               # cameras per sample in the dataset
+  num_input_views: 5          # views fed to the geometry encoder
+  num_target_views: 5         # novel views to render and supervise
+  random_split: true          # randomize input/target partition order per batch
+
+  train_batch_size: 8         # per GPU
+  val_batch_size: 4
+  num_epochs: 1000
+  num_workers: 8
+  num_gpus: 1
+  num_nodes: 1
+
+  max_fwdbwd_passes: 152000   # total gradient steps (controls OneCycleLR span)
+  grad_checkpoint_every: 1
+
+  log_every_n_steps: 10
+  check_val_every_n_epoch: 1
+
+  train_fraction: 0.9
+
+  # Loss weights (0 = disabled)
+  l2_loss_weight: 1.0
+  gs_reg_loss_weight: 0.0
+  perceptual_loss_weight: 0.2
+
+# ---------------------------------------------------------------------------
+# Optimizer  (AdamW + OneCycleLR)
+# ---------------------------------------------------------------------------
+optimizer:
+  lr: 4.0e-4
+  beta1: 0.9
+  beta2: 0.95
+  wd: 0.05
+  warmup: 3000
+  div_factor: 1.0
+  final_div_factor: 1.0
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+data:
+  data_dir: /PATH/TO/MULTIVIEW/DATA   # root of a beast extract_3d output directory
+
+# ---------------------------------------------------------------------------
+# Runtime flags
+# ---------------------------------------------------------------------------
+inference: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,6 +177,39 @@ def config_erayzer(config_erayzer_path) -> dict:
 
 
 @pytest.fixture
+def config_beast3d_path() -> Path:
+    return ROOT.joinpath('configs/multiview/beast3d.yaml')
+
+
+@pytest.fixture
+def config_beast3d(config_beast3d_path) -> dict:
+    # shrink the reference config for fast CPU unit tests; use_dinov3=False keeps
+    # the small learned patch tokenizer (no DINOv3 download / 768-dim requirement)
+    config = load_config(config_beast3d_path)
+    config['model']['use_dinov3'] = False
+    config['model']['image_tokenizer']['image_size'] = 32
+    config['model']['image_tokenizer']['patch_size'] = 8   # 4×4 = 16 tokens per view
+    config['model']['target_image']['height'] = 32
+    config['model']['target_image']['width'] = 32
+    config['model']['transformer']['d'] = 32
+    config['model']['transformer']['d_head'] = 8
+    config['model']['transformer']['encoder_n_layer'] = 0   # GT cameras, no pose branch
+    config['model']['transformer']['encoder_geom_n_layer'] = 2
+    config['model']['transformer']['use_qk_norm'] = False
+    config['model']['transformer']['special_init'] = False
+    config['model']['transformer']['depth_init'] = False
+    config['model']['gaussians']['sh_degree'] = 0
+    config['training']['num_views'] = 3
+    config['training']['num_input_views'] = 2
+    config['training']['num_target_views'] = 1
+    config['training']['grad_checkpoint_every'] = 1
+    config['training']['max_fwdbwd_passes'] = 100
+    config['training']['perceptual_loss_weight'] = 0.0   # VGG needs > 8px images
+    config['optimizer']['warmup'] = 10   # must be < max_fwdbwd_passes
+    return copy.deepcopy(config)
+
+
+@pytest.fixture
 def aug_pipeline() -> Callable:
     params_dict = expand_imgaug_str_to_dict('default')
     pipeline = imgaug_pipeline(params_dict)

--- a/tests/models/beast3d/conftest.py
+++ b/tests/models/beast3d/conftest.py
@@ -1,0 +1,87 @@
+"""Fixtures for BEAST3D integration tests."""
+
+import copy
+import gc
+from pathlib import Path
+
+import lightning.pytorch as pl
+import pytest
+import torch
+
+from beast.api.model import Model
+from beast.data.datamodules import MultiViewDataModule
+
+
+def _gsplat_cuda_available() -> bool:
+    """Return True if gsplat's CUDA extension compiled and loaded successfully."""
+    try:
+        import gsplat.cuda._backend as gsplat_backend
+        return getattr(gsplat_backend, '_C', None) is not None
+    except Exception:
+        return False
+
+
+# Applied to every integration test; skips gracefully when gsplat CUDA is absent.
+requires_gsplat_cuda = pytest.mark.skipif(
+    not _gsplat_cuda_available(),
+    reason='gsplat CUDA extension not available (no nvcc / unsupported GPU arch)',
+)
+
+
+def _multiview_masks_available(data_dir: Path) -> bool:
+    """Return True if the multiview fixture contains any segmentation mask file."""
+    return any(Path(data_dir).rglob('mask*'))
+
+
+@pytest.fixture
+def run_beast3d_model_test(tmp_path, multiview_data_dir):
+    """Build, train, and run inference on a BEAST3D model.
+
+    Mirrors run_erayzer_model_test but uses GT cameras + foreground masks. Skips
+    when the multiview fixture lacks masks (BEAST3D requires use_mask=True).
+    DINOv3 is disabled so the test needs no network download.
+    """
+    def _run(config: dict) -> None:
+        if not _multiview_masks_available(multiview_data_dir):
+            pytest.skip('multiview test fixture has no segmentation masks for BEAST3D')
+        config = copy.deepcopy(config)
+        config['model']['use_dinov3'] = False
+        config['data']['data_dir'] = str(multiview_data_dir)
+        config['training']['train_batch_size'] = 2
+        config['training']['val_batch_size'] = 2
+        config['training']['num_workers'] = 0
+        config['training']['log_every_n_steps'] = 1
+        config['training']['check_val_every_n_epoch'] = 1
+        config['training']['max_fwdbwd_passes'] = 20
+        config['optimizer']['warmup'] = 5
+
+        model = Model.from_config(config)
+        try:
+            model.train(tmp_path)
+
+            dm = MultiViewDataModule(
+                data_dir=multiview_data_dir,
+                image_size=config['model']['image_tokenizer']['image_size'],
+                train_batch_size=2,
+                val_batch_size=2,
+                train_fraction=0.8,
+                num_workers=0,
+                use_mask=True,
+            )
+            dm.setup()
+            trainer = pl.Trainer(accelerator='gpu', devices=1, logger=False)
+            preds = trainer.predict(
+                model.model,
+                dataloaders=dm.val_dataloader(),
+                return_predictions=True,
+            )
+            assert preds is not None and len(preds) > 0
+
+            assert model.model_dir is not None
+            assert len(list(model.model_dir.rglob('*.ckpt'))) == 1
+        finally:
+            del model
+            gc.collect()
+            torch.cuda.empty_cache()
+
+    return _run

--- a/tests/models/beast3d/test_beast3d_model.py
+++ b/tests/models/beast3d/test_beast3d_model.py
@@ -1,0 +1,321 @@
+"""Tests for beast.models.beast3d.beast3d_model.Beast3D."""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn as nn
+from pydantic import ValidationError
+
+from beast.models.beast3d.beast3d_config import Beast3DModelConfig
+from beast.models.beast3d.beast3d_model import Beast3D
+from tests.models.beast3d.conftest import requires_gsplat_cuda
+
+_MIN_TRANSFORMER = {'d': 768, 'd_head': 64, 'encoder_geom_n_layer': 16}
+
+
+class _FakeDinoV3(nn.Module):
+    """Stand-in for beast.nn.dino.DinoV3 that needs no network download.
+
+    Emits (H/8 x W/8) patch tokens to match the shrunk test config (image_size
+    32, patch_size 8 → 4x4 = 16 tokens), with a configurable embed_dim.
+    """
+
+    def __init__(self, model_name: str = '', freeze: bool = True, embed_dim: int = 32) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.proj = nn.Linear(3, embed_dim)
+        if freeze:
+            for p in self.parameters():
+                p.requires_grad = False
+
+    def forward(self, images):
+        b, v, _, h, w = images.shape
+        n = (h // 8) * (w // 8)
+        patch = torch.zeros(b, v, n, self.embed_dim, device=images.device)
+        cls = torch.zeros(b, v, self.embed_dim, device=images.device)
+        return patch, cls
+
+
+def _gt_cameras(b: int, v: int) -> dict:
+    """Identity-ish GT cameras (in-pixels intrinsics) for a 32x32 render."""
+    c2w = torch.eye(4).reshape(1, 1, 4, 4).repeat(b, v, 1, 1)
+    fxfycxcy = torch.tensor([40.0, 40.0, 16.0, 16.0]).reshape(1, 1, 4).repeat(b, v, 1)
+    return {'c2w': c2w, 'fxfycxcy': fxfycxcy}
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DModelConfig
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DModelConfig:
+    """Test the Beast3DModelConfig schema."""
+
+    def test_valid_config_defaults(self) -> None:
+        cfg = Beast3DModelConfig.model_validate(
+            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER},
+        )
+        assert cfg.model_class == 'beast3d'
+        assert cfg.use_dinov3 is True
+        assert cfg.freeze_dinov3 is True
+        assert cfg.frustum_constraint is True
+        assert cfg.random_background is True
+        assert cfg.mask_loss_weight == 0.1
+
+    def test_wrong_model_class_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Beast3DModelConfig.model_validate(
+                {'model_class': 'erayzer', 'transformer': _MIN_TRANSFORMER},
+            )
+
+    def test_missing_transformer_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Beast3DModelConfig.model_validate({'model_class': 'beast3d'})
+
+    def test_inherits_erayzer_fields(self) -> None:
+        # hard_pixelalign and gaussians come from the ERayZer base config
+        cfg = Beast3DModelConfig.model_validate(
+            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER, 'hard_pixelalign': True},
+        )
+        assert cfg.hard_pixelalign is True
+        assert cfg.gaussians.sh_degree == 3
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DConstruction
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DConstruction:
+    """Test Beast3D model construction."""
+
+    def test_construction_without_dinov3_keeps_patch_tokenizer(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        assert hasattr(model, 'image_tokenizer')
+        assert not hasattr(model, 'dinov3')
+        # GT cameras → pose-prediction branch is never built
+        assert not hasattr(model, 'transformer_encoder')
+        assert not hasattr(model, 'pose_predictor')
+
+    def test_construction_with_dinov3_swaps_tokenizer(self, config_beast3d) -> None:
+        config = copy.deepcopy(config_beast3d)
+        config['model']['use_dinov3'] = True
+        d = config['model']['transformer']['d']
+        with patch(
+            'beast.models.beast3d.beast3d_model.DinoV3',
+            side_effect=lambda **kw: _FakeDinoV3(embed_dim=d, **kw),
+        ):
+            model = Beast3D(config)
+        assert hasattr(model, 'dinov3')
+        assert not hasattr(model, 'image_tokenizer')
+
+    def test_dinov3_embed_dim_mismatch_raises(self, config_beast3d) -> None:
+        config = copy.deepcopy(config_beast3d)
+        config['model']['use_dinov3'] = True
+        with patch(
+            'beast.models.beast3d.beast3d_model.DinoV3',
+            side_effect=lambda **kw: _FakeDinoV3(embed_dim=999, **kw),
+        ):
+            with pytest.raises(ValueError, match='embed_dim'):
+                Beast3D(config)
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DResolveCameras
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DResolveCameras:
+    """Test the GT-camera _resolve_cameras override."""
+
+    def test_returns_gt_cameras_unnormalized(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        data = _gt_cameras(b=2, v=3)
+        c2w, fxfycxcy, normalized = model._resolve_cameras(
+            None, b=2, v_all=3, n=16, data=data, device=torch.device('cpu'),
+        )
+        assert normalized is False
+        assert c2w.shape == (2, 3, 4, 4)
+        assert fxfycxcy.shape == (2, 3, 4)
+        assert torch.allclose(c2w, data['c2w'])
+
+    def test_pads_cameras_to_v_all(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        data = _gt_cameras(b=1, v=3)
+        c2w, fxfycxcy, _ = model._resolve_cameras(
+            None, b=1, v_all=10, n=16, data=data, device=torch.device('cpu'),
+        )
+        assert c2w.shape == (1, 10, 4, 4)
+        assert fxfycxcy.shape == (1, 10, 4)
+        # padded views repeat the last real view
+        assert torch.allclose(c2w[:, 3:], data['c2w'][:, -1:].expand(-1, 7, -1, -1))
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DTokenize
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DTokenize:
+    """Test the _tokenize_images override."""
+
+    def test_without_dinov3_matches_base(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        h = w = config_beast3d['model']['image_tokenizer']['image_size']
+        images = torch.rand(1, 2, 3, h, w)
+        out = model._tokenize_images(images)
+        expected = model.image_tokenizer(images * 2.0 - 1.0)
+        assert torch.allclose(out, expected)
+
+    def test_with_dinov3_returns_flat_tokens(self, config_beast3d) -> None:
+        config = copy.deepcopy(config_beast3d)
+        config['model']['use_dinov3'] = True
+        d = config['model']['transformer']['d']
+        with patch(
+            'beast.models.beast3d.beast3d_model.DinoV3',
+            side_effect=lambda **kw: _FakeDinoV3(embed_dim=d, **kw),
+        ):
+            model = Beast3D(config)
+        h = w = config['model']['image_tokenizer']['image_size']
+        images = torch.rand(2, 3, 3, h, w)
+        out = model._tokenize_images(images)
+        assert out.shape == (2 * 3, (h // 8) * (w // 8), d)
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DBackgroundAndTarget
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DBackgroundAndTarget:
+    """Test _sample_background and _prepare_target."""
+
+    def test_background_none_in_eval(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        model.eval()
+        assert model._sample_background(torch.device('cpu'), torch.float32) is None
+
+    def test_background_random_in_train(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        model.train()
+        bg = model._sample_background(torch.device('cpu'), torch.float32)
+        assert bg is not None and bg.shape == (3,)
+
+    def test_prepare_target_no_mask_is_identity(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        target = torch.rand(2, 1, 3, 8, 8)
+        out, mask = model._prepare_target(
+            target, {}, torch.zeros(2, 1, dtype=torch.long),
+            torch.zeros(2, 1, dtype=torch.long), None,
+        )
+        assert out is target
+        assert mask is None
+
+    def test_prepare_target_composites_background(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        b, v, h, w = 2, 1, 8, 8
+        target = torch.ones(b, v, 3, h, w)
+        full_mask = torch.zeros(b, 3, 1, h, w)  # 3 views available, fg mask = 0 everywhere
+        data = {'input_mask': full_mask}
+        batch_idx = torch.arange(b).unsqueeze(1)
+        target_idx = torch.zeros(b, v, dtype=torch.long)
+        bg = torch.tensor([0.2, 0.4, 0.6])
+        out, mask = model._prepare_target(target, data, batch_idx, target_idx, bg)
+        assert mask.shape == (b, v, 1, h, w)
+        # with a zero foreground mask the whole image becomes the background colour
+        assert torch.allclose(out[:, :, 0], torch.full((b, v, h, w), 0.2))
+        assert torch.allclose(out[:, :, 2], torch.full((b, v, h, w), 0.6))
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DComputeLoss
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DComputeLoss:
+    """Test the mask/alpha term added to compute_loss."""
+
+    def _base_kwargs(self, b=2, v=1, h=8, w=8) -> dict:
+        return {
+            'render': torch.rand(b, v, 3, h, w),
+            'target_image': torch.rand(b, v, 3, h, w),
+        }
+
+    def test_adds_mask_term_when_alpha_and_mask_present(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        b, v, h, w = 2, 1, 8, 8
+        kwargs = self._base_kwargs(b, v, h, w)
+        kwargs['render_alphas'] = torch.rand(b, v, 1, h, w)
+        kwargs['pixel_mask'] = (torch.rand(b, v, 1, h, w) > 0.5).float()
+        loss, log_list = model.compute_loss('train', **kwargs)
+        assert loss.ndim == 0
+        assert any(d['name'] == 'train_mask' for d in log_list)
+
+    def test_no_mask_term_without_pixel_mask(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        kwargs = self._base_kwargs()
+        kwargs['render_alphas'] = torch.rand(2, 1, 1, 8, 8)
+        kwargs['pixel_mask'] = None
+        _, log_list = model.compute_loss('train', **kwargs)
+        assert not any(d['name'] == 'train_mask' for d in log_list)
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DForward
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DForward:
+    """Test the full forward pass with a mocked renderer (no gsplat)."""
+
+    @staticmethod
+    def _fake_render(xyz, features, scaling, rotation, opacity,
+                     height, width, C2W, fxfycxcy,
+                     frustum_constraint=False, backgrounds=None):
+        return SimpleNamespace(
+            render=torch.zeros(C2W.shape[0], C2W.shape[1], 3, height, width),
+            depth=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
+            alpha=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
+        )
+
+    def test_forward_uses_gt_cameras(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        model.eval()
+        b, v, h, w = 1, 3, 32, 32
+        data = {'image': torch.rand(b, v, 3, h, w), **_gt_cameras(b, v)}
+        with patch.object(model.renderer, 'forward', side_effect=self._fake_render):
+            result = model(data)
+        assert hasattr(result, 'render')
+        assert hasattr(result, 'render_alphas')
+        # GT cameras flow straight through to the input cameras
+        assert torch.allclose(result.c2w_input, data['c2w'][:, result.input_indices[0]])
+
+    def test_forward_with_mask_sets_pixel_mask(self, config_beast3d) -> None:
+        model = Beast3D(config_beast3d)
+        model.eval()
+        b, v, h, w = 1, 3, 32, 32
+        data = {
+            'image': torch.rand(b, v, 3, h, w),
+            'input_mask': (torch.rand(b, v, 1, h, w) > 0.5).float(),
+            **_gt_cameras(b, v),
+        }
+        with patch.object(model.renderer, 'forward', side_effect=self._fake_render):
+            result = model(data)
+        assert result.pixel_mask is not None
+        assert result.pixel_mask.shape[2] == 1  # single foreground channel
+
+
+# ---------------------------------------------------------------------------
+# TestBeast3DIntegration
+# ---------------------------------------------------------------------------
+
+
+class TestBeast3DIntegration:
+    """End-to-end train + predict (requires gsplat CUDA and mask fixtures)."""
+
+    @requires_gsplat_cuda
+    def test_integration_basic(self, config_beast3d, run_beast3d_model_test) -> None:
+        run_beast3d_model_test(config_beast3d)

--- a/tests/models/beast3d/test_beast3d_model.py
+++ b/tests/models/beast3d/test_beast3d_model.py
@@ -7,13 +7,9 @@ from unittest.mock import patch
 import pytest
 import torch
 import torch.nn as nn
-from pydantic import ValidationError
 
-from beast.models.beast3d.beast3d_config import Beast3DModelConfig
 from beast.models.beast3d.beast3d_model import Beast3D
 from tests.models.beast3d.conftest import requires_gsplat_cuda
-
-_MIN_TRANSFORMER = {'d': 768, 'd_head': 64, 'encoder_geom_n_layer': 16}
 
 
 class _FakeDinoV3(nn.Module):
@@ -44,44 +40,6 @@ def _gt_cameras(b: int, v: int) -> dict:
     c2w = torch.eye(4).reshape(1, 1, 4, 4).repeat(b, v, 1, 1)
     fxfycxcy = torch.tensor([40.0, 40.0, 16.0, 16.0]).reshape(1, 1, 4).repeat(b, v, 1)
     return {'c2w': c2w, 'fxfycxcy': fxfycxcy}
-
-
-# ---------------------------------------------------------------------------
-# TestBeast3DModelConfig
-# ---------------------------------------------------------------------------
-
-
-class TestBeast3DModelConfig:
-    """Test the Beast3DModelConfig schema."""
-
-    def test_valid_config_defaults(self) -> None:
-        cfg = Beast3DModelConfig.model_validate(
-            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER},
-        )
-        assert cfg.model_class == 'beast3d'
-        assert cfg.use_dinov3 is True
-        assert cfg.freeze_dinov3 is True
-        assert cfg.frustum_constraint is True
-        assert cfg.random_background is True
-        assert cfg.mask_loss_weight == 0.1
-
-    def test_wrong_model_class_raises(self) -> None:
-        with pytest.raises(ValidationError):
-            Beast3DModelConfig.model_validate(
-                {'model_class': 'erayzer', 'transformer': _MIN_TRANSFORMER},
-            )
-
-    def test_missing_transformer_raises(self) -> None:
-        with pytest.raises(ValidationError):
-            Beast3DModelConfig.model_validate({'model_class': 'beast3d'})
-
-    def test_inherits_erayzer_fields(self) -> None:
-        # hard_pixelalign and gaussians come from the ERayZer base config
-        cfg = Beast3DModelConfig.model_validate(
-            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER, 'hard_pixelalign': True},
-        )
-        assert cfg.hard_pixelalign is True
-        assert cfg.gaussians.sh_degree == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/beast3d/test_beast3d_model.py
+++ b/tests/models/beast3d/test_beast3d_model.py
@@ -134,8 +134,9 @@ class TestBeast3DResolveCameras:
     def test_returns_gt_cameras_unnormalized(self, config_beast3d) -> None:
         model = Beast3D(config_beast3d)
         data = _gt_cameras(b=2, v=3)
+        # img_tokens is ignored by the GT-camera override; pass a throwaway tensor
         c2w, fxfycxcy, normalized = model._resolve_cameras(
-            None, b=2, v_all=3, n=16, data=data, device=torch.device('cpu'),
+            torch.empty(0), b=2, v_all=3, n=16, data=data, device=torch.device('cpu'),
         )
         assert normalized is False
         assert c2w.shape == (2, 3, 4, 4)
@@ -146,7 +147,7 @@ class TestBeast3DResolveCameras:
         model = Beast3D(config_beast3d)
         data = _gt_cameras(b=1, v=3)
         c2w, fxfycxcy, _ = model._resolve_cameras(
-            None, b=1, v_all=10, n=16, data=data, device=torch.device('cpu'),
+            torch.empty(0), b=1, v_all=10, n=16, data=data, device=torch.device('cpu'),
         )
         assert c2w.shape == (1, 10, 4, 4)
         assert fxfycxcy.shape == (1, 10, 4)
@@ -224,6 +225,7 @@ class TestBeast3DBackgroundAndTarget:
         target_idx = torch.zeros(b, v, dtype=torch.long)
         bg = torch.tensor([0.2, 0.4, 0.6])
         out, mask = model._prepare_target(target, data, batch_idx, target_idx, bg)
+        assert mask is not None
         assert mask.shape == (b, v, 1, h, w)
         # with a zero foreground mask the whole image becomes the background colour
         assert torch.allclose(out[:, :, 0], torch.full((b, v, h, w), 0.2))

--- a/tests/models/erayzer/test_erayzer_model.py
+++ b/tests/models/erayzer/test_erayzer_model.py
@@ -591,7 +591,8 @@ class TestERayZer:
         data = {'image': torch.rand(b, v, 3, h, w)}
 
         def _fake_render(xyz, features, scaling, rotation, opacity,
-                         height, width, C2W, fxfycxcy):
+                         height, width, C2W, fxfycxcy,
+                         frustum_constraint=False, backgrounds=None):
             return SimpleNamespace(
                 render=torch.zeros(C2W.shape[0], C2W.shape[1], 3, height, width),
                 depth=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
@@ -619,7 +620,8 @@ class TestERayZer:
         data = {'image': torch.rand(b, v, 3, h, w)}
 
         def _fake_render(xyz, features, scaling, rotation, opacity,
-                         height, width, C2W, fxfycxcy):
+                         height, width, C2W, fxfycxcy,
+                         frustum_constraint=False, backgrounds=None):
             return SimpleNamespace(
                 render=torch.zeros(C2W.shape[0], C2W.shape[1], 3, height, width),
                 depth=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
@@ -636,6 +638,51 @@ class TestERayZer:
         opt_cfg = model.configure_optimizers()
         assert 'optimizer' in opt_cfg
         assert 'lr_scheduler' in opt_cfg
+
+    def test_tokenize_images_default_matches_image_tokenizer(self, config_erayzer) -> None:
+        # the default _tokenize_images hook rescales [0,1] → [-1,1] then tokenizes
+        model = ERayZer(config_erayzer)
+        h = w = config_erayzer['model']['image_tokenizer']['image_size']
+        images = torch.rand(1, 2, 3, h, w)
+        out = model._tokenize_images(images)
+        expected = model.image_tokenizer(images * 2.0 - 1.0)
+        assert torch.allclose(out, expected)
+
+    def test_sample_background_default_is_none(self, config_erayzer) -> None:
+        model = ERayZer(config_erayzer)
+        assert model._sample_background(torch.device('cpu'), torch.float32) is None
+
+    def test_prepare_target_default_is_identity(self, config_erayzer) -> None:
+        model = ERayZer(config_erayzer)
+        target = torch.rand(2, 1, 3, 8, 8)
+        out, mask = model._prepare_target(
+            target, {}, torch.zeros(2, 1, dtype=torch.long),
+            torch.zeros(2, 1, dtype=torch.long), None,
+        )
+        assert out is target
+        assert mask is None
+
+    def test_forward_exposes_alpha_and_mask(self, config_erayzer) -> None:
+        # base ERayZer forward now exposes render_alphas and a (None) pixel_mask
+        model = ERayZer(config_erayzer)
+        model.eval()
+        b, v, h, w = 1, 3, 32, 32
+        data = {'image': torch.rand(b, v, 3, h, w)}
+
+        def _fake_render(xyz, features, scaling, rotation, opacity,
+                         height, width, C2W, fxfycxcy,
+                         frustum_constraint=False, backgrounds=None):
+            return SimpleNamespace(
+                render=torch.zeros(C2W.shape[0], C2W.shape[1], 3, height, width),
+                depth=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
+                alpha=torch.zeros(C2W.shape[0], C2W.shape[1], 1, height, width),
+            )
+
+        with patch.object(model.renderer, 'forward', side_effect=_fake_render):
+            result = model(data)
+
+        assert hasattr(result, 'render_alphas')
+        assert result.pixel_mask is None  # base ERayZer supervises without a mask
 
 
 # ---------------------------------------------------------------------------

--- a/tests/rendering/test_gaussians_renderer.py
+++ b/tests/rendering/test_gaussians_renderer.py
@@ -8,6 +8,7 @@ from beast.rendering.gaussians_renderer import (
     SH2RGB,
     build_rotation,
     build_scaling_rotation,
+    camera_frustum_constraint,
     strip_lowerdiag,
     strip_symmetric,
 )
@@ -139,3 +140,55 @@ class TestSH2RGB:
     def test_output_shape_preserved(self) -> None:
         sh = torch.randn(8, 3)
         assert SH2RGB(sh).shape == (8, 3)
+
+
+class TestCameraFrustumConstraint:
+    """Test the camera_frustum_constraint function (CPU-only, no rasterizer)."""
+
+    @staticmethod
+    def _identity_cam() -> tuple[torch.Tensor, torch.Tensor]:
+        """A single camera at the origin looking down +z with a 64x64 image."""
+        c2w = torch.eye(4).unsqueeze(0)  # [1, 4, 4]
+        # fx = fy = 100, principal point at image centre (cx = cy = 32)
+        fxfycxcy = torch.tensor([[100.0, 100.0, 32.0, 32.0]])
+        return c2w, fxfycxcy
+
+    def test_point_in_front_kept(self) -> None:
+        c2w, fxfycxcy = self._identity_cam()
+        xyz = torch.tensor([[0.0, 0.0, 2.0]])  # on-axis, in front
+        opacity = torch.tensor([[0.8]])
+        out = camera_frustum_constraint(xyz, opacity, c2w, fxfycxcy, 64, 64)
+        assert torch.allclose(out, opacity)
+
+    def test_point_behind_camera_zeroed(self) -> None:
+        c2w, fxfycxcy = self._identity_cam()
+        xyz = torch.tensor([[0.0, 0.0, -2.0]])  # behind the camera
+        opacity = torch.tensor([[0.8]])
+        out = camera_frustum_constraint(xyz, opacity, c2w, fxfycxcy, 64, 64)
+        assert out.item() == 0.0
+
+    def test_point_outside_fov_zeroed(self) -> None:
+        c2w, fxfycxcy = self._identity_cam()
+        xyz = torch.tensor([[10.0, 0.0, 2.0]])  # far off-axis, projects outside image
+        opacity = torch.tensor([[0.8]])
+        out = camera_frustum_constraint(xyz, opacity, c2w, fxfycxcy, 64, 64)
+        assert out.item() == 0.0
+
+    def test_intersection_of_two_cameras(self) -> None:
+        # cam0 at origin sees (0,0,2); cam1 shifted far along +x does not.
+        c2w0 = torch.eye(4)
+        c2w1 = torch.eye(4)
+        c2w1[0, 3] = 100.0  # translate camera centre by +100 in world x
+        c2w = torch.stack([c2w0, c2w1])  # [2, 4, 4]
+        fxfycxcy = torch.tensor([[100.0, 100.0, 32.0, 32.0]]).expand(2, -1)
+        xyz = torch.tensor([[0.0, 0.0, 2.0]])
+        opacity = torch.tensor([[0.8]])
+        out = camera_frustum_constraint(xyz, opacity, c2w, fxfycxcy, 64, 64)
+        assert out.item() == 0.0  # not seen by cam1 → excluded from the intersection
+
+    def test_opacity_shape_preserved(self) -> None:
+        c2w, fxfycxcy = self._identity_cam()
+        xyz = torch.randn(50, 3)
+        opacity = torch.rand(50, 1)
+        out = camera_frustum_constraint(xyz, opacity, c2w, fxfycxcy, 64, 64)
+        assert out.shape == opacity.shape

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from beast.config import (
+    Beast3DBeastConfig,
     BeastConfig,
     ERayZerBeastConfig,
     OptimizerConfig,
@@ -13,6 +14,7 @@ from beast.config import (
     get_beast_config_class,
 )
 from beast.io import load_config
+from beast.models.beast3d.beast3d_config import Beast3DModelConfig
 from beast.models.beast_resnet.beast_resnet_config import ResnetModelParams
 from beast.models.beast_vit.beast_vit_config import VitModelParams
 from beast.models.erayzer.erayzer_config import ERayZerOptimizerConfig, ERayZerTrainingConfig
@@ -53,6 +55,8 @@ _MINIMAL_ERAYZER = {
     'optimizer': {'lr': 4e-4},
     'data': {'data_dir': '/path/to/data'},
 }
+
+_MIN_TRANSFORMER = {'d': 768, 'd_head': 64, 'encoder_geom_n_layer': 16}
 
 
 class TestBeastConfig:
@@ -218,11 +222,47 @@ class TestERayZerBeastConfig:
         assert 'beta1' in dumped['optimizer']
 
 
+class TestBeast3DModelConfig:
+    """Test the Beast3DModelConfig schema."""
+
+    def test_valid_config_defaults(self) -> None:
+        cfg = Beast3DModelConfig.model_validate(
+            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER},
+        )
+        assert cfg.model_class == 'beast3d'
+        assert cfg.use_dinov3 is True
+        assert cfg.freeze_dinov3 is True
+        assert cfg.frustum_constraint is True
+        assert cfg.random_background is True
+        assert cfg.mask_loss_weight == 0.1
+
+    def test_wrong_model_class_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Beast3DModelConfig.model_validate(
+                {'model_class': 'erayzer', 'transformer': _MIN_TRANSFORMER},
+            )
+
+    def test_missing_transformer_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Beast3DModelConfig.model_validate({'model_class': 'beast3d'})
+
+    def test_inherits_erayzer_fields(self) -> None:
+        # hard_pixelalign and gaussians come from the ERayZer base config
+        cfg = Beast3DModelConfig.model_validate(
+            {'model_class': 'beast3d', 'transformer': _MIN_TRANSFORMER, 'hard_pixelalign': True},
+        )
+        assert cfg.hard_pixelalign is True
+        assert cfg.gaussians.sh_degree == 3
+
+
 class TestGetBeastConfigClass:
     """Test the get_beast_config_class dispatcher."""
 
     def test_erayzer_returns_erayzer_beast_config(self) -> None:
         assert get_beast_config_class('erayzer') is ERayZerBeastConfig
+
+    def test_beast3d_returns_beast3d_beast_config(self) -> None:
+        assert get_beast_config_class('beast3d') is Beast3DBeastConfig
 
     def test_resnet_falls_back_to_beast_config(self) -> None:
         assert get_beast_config_class('resnet') is BeastConfig


### PR DESCRIPTION
… 3DGS

Port multi-view BEAST3D into the beast repo as a full-parity ERayZer subclass, following docs/developer_guide.md.

Shared, opt-in changes (erayzer behavior unchanged, verified):
- gaussians_renderer: add camera_frustum_constraint + opt-in frustum_constraint kwarg; capture render_alphas (was discarded) so mask loss has real alphas; accept bg_color=None.
- erayzer_model: add _tokenize_images / _sample_background / _prepare_target subclass hooks to forward; thread frustum_constraint/backgrounds into Renderer; expose render_alphas/pixel_mask outputs.

BEAST3D (beast/models/beast3d/):
- frozen DINOv3 tokenizer with ImageNet normalization (the DinoV3 wrapper omits it)
- GT cameras via _resolve_cameras; pose branch disabled with encoder_n_layer=0
- frustum-constrained render, random-background compositing, masked alpha loss
- registry + config dispatch (Beast3DBeastConfig) + train.py MultiViewDataModule routing with use_mask=True

Config: configs/multiview/beast3d.yaml (reference template). The machine-specific cheese3d fine-tune config (data_dir + init_checkpoint) is kept local and gitignored, alongside erayzer_cheese3d_ft.yaml.

Tests: tests/models/beast3d/ (19 CPU unit tests + 1 gsplat-gated integration test); renderer + base-ERayZer regression tests. ruff + pyright clean.