### PR TITLE
update publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,9 +54,6 @@ jobs:
         fi
         echo "Version verification passed"
 
-    - name: Install dependencies
-      run: poetry install --only-root
-
     - name: Build package
       run: poetry build
 


### PR DESCRIPTION
`gsplat` is a git dependency that requires `torch` to build its C extensions. In the publish workflow, the `poetry install --only-root` step triggers dependency resolution/building for `gsplat`, but `torch` isn't available yet.

This PR removes the `poetry install --only-root` step entirely. It's not needed —  poetry build just packages the source files into a wheel/sdist without needing to install or compile any dependencies. gsplat will only be compiled when users install `beast-backbones` on their own machines (where torch is already present).